### PR TITLE
change "main" to "master" in ci config file and update README links t…

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -2,9 +2,9 @@ name: Test MacOS
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -2,9 +2,9 @@ name: Test Ubuntu
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -2,9 +2,9 @@ name: Test Windows
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-![Test Ubuntu](https://github.com/roaminroe/koinos-sdk-as/actions/workflows/test-ubuntu.yml/badge.svg)
-![Test Windows](https://github.com/roaminroe/koinos-sdk-as/actions/workflows/test-windows.yml/badge.svg)
-![Test MacOS](https://github.com/roaminroe/koinos-sdk-as/actions/workflows/test-macos.yml/badge.svg)
+![Test Ubuntu](https://github.com/koinos/koinos-sdk-as/actions/workflows/test-ubuntu.yml/badge.svg)
+![Test Windows](https://github.com/koinos/koinos-sdk-as/actions/workflows/test-windows.yml/badge.svg)
+![Test MacOS](https://github.com/koinos/koinos-sdk-as/actions/workflows/test-macos.yml/badge.svg)
 
 # koinos-sdk-as
 AssemblyScript (AS) Software Development Toolkit (SDK) for the Koinos Blockchain
 
-See documentation: https://roaminroe.github.io/koinos-sdk-as/
+See documentation: https://koinos.github.io/koinos-sdk-as/
 
 Learn how to create smart contracts by looking at the examples repo: https://github.com/roaminroe/koinos-sdk-as-examples
 


### PR DESCRIPTION
Resolves ci not being triggered when pushing to the "master" branch (due to change of branch name)

## Brief description
- update the branch name from "main" to "master" in the workflow config files
- update links in README to show the badges of this repo (instead of my personal one)
- update link to auto-generated documentation

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
