### PR TITLE
MockVM.clearLogs() function

### DIFF
--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -188,4 +188,14 @@ describe('MockVM', () => {
     expect(Arrays.equal(bytes, val2)).toBe(true);
 
   });
+
+  it("should handle logs", () => {
+    System.log("log 1");
+    expect(MockVM.getLogs()).toStrictEqual(["log 1"]);
+    System.log("log 2");
+    expect(MockVM.getLogs()).toStrictEqual(["log 1", "log 2"]);
+    MockVM.clearLogs();
+    System.log("log 3");
+    expect(MockVM.getLogs()).toStrictEqual(["log 3"]);
+  });
 });

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -327,6 +327,23 @@ export namespace MockVM {
   }
 
   /**
+   * Remove the current logs
+   * @example
+   * ```ts
+   * System.log('log 1');
+   * System.log('log 2');
+   * MockVM.clearLogs();
+   * System.log('log 3');
+   * System.log('log 4');
+   * console.log(MockVM.getLogs().join(","));
+   * // log 3,log 4
+   * ```
+   */
+  export function clearLogs(): void {
+    System.putBytes(METADATA_SPACE, 'logs', new Uint8Array(0));
+  }
+
+  /**
     * Get logs set when calling System.log()
     * @returns { string[] }
     * @example


### PR DESCRIPTION
## Brief description
Function to clear the current logs.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```
 [Success]: ✔ should set the authorities RTrace: +82
 [Success]: ✔ should set the call contract results RTrace: +67
 [Success]: ✔ should reset the MockVM database RTrace: +65
 [Success]: ✔ should handle transactions RTrace: +187
[Log] log 1
[Log] log 2
[Log] log 3
 [Success]: ✔ should handle logs RTrace: +141

    [File]: /root/koinos/koinos-sdk-as/__tests__/mockVM.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 13 pass,  0 fail, 13 total
    [Time]: 597.397ms
```
