### PR TITLE
Safemath u128 fix

### DIFF
--- a/__tests__/safeMath.spec.ts
+++ b/__tests__/safeMath.spec.ts
@@ -158,8 +158,8 @@ describe('SafeMath', () => {
       }).toThrow();
 
       const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not add 340282366920938463463374607431768211455 to 1');
-      expect(logs[1]).toBe('could not add 1 to 340282366920938463463374607431768211455');
+      expect(logs[0]).toBe('could not add');
+      expect(logs[1]).toBe('could not add');
     });
 
     it('adds correctly if it does not overflow and the result is positive', () => {
@@ -341,7 +341,7 @@ describe('SafeMath', () => {
       }).toThrow();
 
       const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not subtract 5678 from 1234');
+      expect(logs[0]).toBe('could not subtract');
     });
 
     it('subtracts correctly if it does not overflow and the result is positive', () => {
@@ -615,8 +615,8 @@ describe('SafeMath', () => {
       }).toThrow();
 
       const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not multiply 340282366920938463463374607431768211455 by 2');
-      expect(logs[1]).toBe('could not multiply 2 by 340282366920938463463374607431768211455');
+      expect(logs[0]).toBe('could not multiply');
+      expect(logs[1]).toBe('could not multiply');
     });
 
     it('reverts on multiplication overflow', () => {
@@ -853,7 +853,7 @@ describe('SafeMath', () => {
       }).toThrow();
 
       const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not divide 5678 by 0');
+      expect(logs[0]).toBe('could not divide');
     });
 
     it('reverts on division by zero with a custom message', () => {
@@ -1125,7 +1125,7 @@ describe('SafeMath', () => {
       }).toThrow();
 
       const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not calulate 5678 modulo 0');
+      expect(logs[0]).toBe('could not calulate modulo');
     });
 
     it('reverts with a 0 divisor with a custom message', () => {

--- a/__tests__/safeMath.spec.ts
+++ b/__tests__/safeMath.spec.ts
@@ -231,9 +231,16 @@ describe('SafeMath', () => {
         SafeMath.add(b, a, 'my message1');
       }).toThrow();
 
+      expect(() => {
+        let a: u128 = u128.Max;
+        let b: u128 = u128.One;
+        SafeMath.add(b, a, 'my message1');
+      }).toThrow();
+
       const logs = MockVM.getLogs();
       expect(logs[0]).toBe('my message');
       expect(logs[1]).toBe('my message1');
+      expect(logs[2]).toBe('my message1');
     });
   });
 
@@ -387,8 +394,15 @@ describe('SafeMath', () => {
         SafeMath.sub(a, b, 'my message');
       }).toThrow();
 
+      expect(() => {
+        let a: u128 = u128.Min;
+        let b: u128 = u128.One;
+        SafeMath.sub(a, b, 'my message1');
+      }).toThrow();
+
       const logs = MockVM.getLogs();
       expect(logs[0]).toBe('my message');
+      expect(logs[1]).toBe('my message');
     });
   });
 
@@ -863,8 +877,15 @@ describe('SafeMath', () => {
         SafeMath.div(a, b, 'my message');
       }).toThrow();
 
+      expect(() => {
+        let a: u128 = u128.Min;
+        let b: u128 = u128.Zero;
+        SafeMath.div(a, b, 'my message1');
+      }).toThrow();
+
       const logs = MockVM.getLogs();
       expect(logs[0]).toBe('my message');
+      expect(logs[1]).toBe('my message');
     });
   });
 

--- a/__tests__/safeMath.spec.ts
+++ b/__tests__/safeMath.spec.ts
@@ -397,7 +397,7 @@ describe('SafeMath', () => {
       expect(() => {
         let a: u128 = u128.Min;
         let b: u128 = u128.One;
-        SafeMath.sub(a, b, 'my message1');
+        SafeMath.sub(a, b, 'my message');
       }).toThrow();
 
       const logs = MockVM.getLogs();
@@ -880,7 +880,7 @@ describe('SafeMath', () => {
       expect(() => {
         let a: u128 = u128.Min;
         let b: u128 = u128.Zero;
-        SafeMath.div(a, b, 'my message1');
+        SafeMath.div(a, b, 'my message');
       }).toThrow();
 
       const logs = MockVM.getLogs();

--- a/assembly/util/safeMath.ts
+++ b/assembly/util/safeMath.ts
@@ -78,8 +78,12 @@ export namespace SafeMath {
     const result = tryAdd(a, b);
 
     if (result.error) {
-      // @ts-ignore valid in AS
-      System.log(message != '' ? message : `could not add ${a.toString()} to ${b.toString()}`);
+      if (isInteger<T>()) {
+        // @ts-ignore valid in AS
+        System.log(message != '' ? message : `could not add ${a.toString()} to ${b.toString()}`);
+      } else {
+        System.log(message != '' ? message : 'could not add');
+      } 
       System.exitContract(1);
     }
 
@@ -151,8 +155,12 @@ export namespace SafeMath {
     const result = trySub(a, b);
 
     if (result.error) {
-      // @ts-ignore valid in AS
-      System.log(message != '' ? message : `could not subtract ${b.toString()} from ${a.toString()}`);
+      if (isInteger<T>()) {
+        // @ts-ignore valid in AS
+        System.log(message != '' ? message : `could not subtract ${b.toString()} from ${a.toString()}`);
+      } else {
+        System.log(message != '' ? message : 'could not subtract');
+      } 
       System.exitContract(1);
     }
 
@@ -247,8 +255,12 @@ export namespace SafeMath {
     const result = tryMul(a, b);
 
     if (result.error) {
-      // @ts-ignore valid in AS
-      System.log(message != '' ? message : `could not multiply ${a.toString()} by ${b.toString()}`);
+      if (isInteger<T>()) {
+        // @ts-ignore valid in AS
+        System.log(message != '' ? message : `could not multiply ${a.toString()} by ${b.toString()}`);
+      } else {
+        System.log(message != '' ? message : 'could not multiply');
+      } 
       System.exitContract(1);
     }
 
@@ -327,8 +339,12 @@ export namespace SafeMath {
     const result = tryDiv(a, b);
 
     if (result.error) {
-      // @ts-ignore valid in AS
-      System.log(message != '' ? message : `could not divide ${a.toString()} by ${b.toString()}`);
+      if (isInteger<T>()) {
+        // @ts-ignore valid in AS
+        System.log(message != '' ? message : `could not divide ${a.toString()} by ${b.toString()}`);
+      } else {
+        System.log(message != '' ? message : 'could not divide');
+      } 
       System.exitContract(1);
     }
 
@@ -407,8 +423,12 @@ export namespace SafeMath {
     const result = tryMod(a, b);
 
     if (result.error) {
-      // @ts-ignore valid in AS
-      System.log(message != '' ? message : `could not calulate ${a.toString()} modulo ${b.toString()}`);
+      if (isInteger<T>()) {
+        // @ts-ignore valid in AS
+        System.log(message != '' ? message : `could not calulate ${a.toString()} modulo ${b.toString()}`);
+      } else {
+        System.log(message != '' ? message : 'could not calulate modulo');
+      } 
       System.exitContract(1);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinos-sdk-as",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "main": "assembly/index.ts",
   "license": "MIT",
   "author": "Koinos Group <contact@koinos.group>",


### PR DESCRIPTION
## Brief description
- the `toString` method available on `u128` from the `as-bignum` package generates wasm bytecode that throws a `-32603:could not parse fizzy module` error when trying to call a contract (while it's working fine when using unit tests)
- will have to investigate the `as-bignum` package, but for now, only call `toString` on "native" wasm integers and return a "generic" message otherwise

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
this contract:
```ts
import { System, u128 } from "koinos-sdk-as";
import { test } from "./proto/test";

export class Test {
 
  test(args: test.test_arguments): test.test_result {
    const val = u128.fromU64(args.val);
    System.log(val.toString());

    return new test.test_result();
  }
}
```

will print:
```sh
🔓 > test.test 3
-32603:could not parse fizzy module
```
