### PR TITLE
Bump vm

### DIFF
--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -7,21 +7,16 @@ const mockAccount2 = Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqE');
 const mockId = StringBytes.stringToBytes("0x12345");
 
 describe('MockVM', () => {
-  it('should set the entry point', () => {
-    const setEntryPoint = 0xc3ab8ff1;
-    MockVM.setEntryPoint(0xc3ab8ff1);
-
-    const getEntryPoint = System.getEntryPoint();
-
-    expect(getEntryPoint).toBe(setEntryPoint);
-  });
 
   it('should set the contract arguments', () => {
+    const setEntryPoint = 0xc3ab8ff1;
+    MockVM.setEntryPoint(0xc3ab8ff1);
     MockVM.setContractArguments(mockAccount);
 
     const getContractArgs = System.getArguments();
 
-    expect(Arrays.equal(getContractArgs, mockAccount)).toBe(true);
+    expect(Arrays.equal(getContractArgs.args, mockAccount)).toBe(true);
+    expect(getContractArgs.entry_point).toBe(setEntryPoint)
   });
 
   it('should set the contract id', () => {
@@ -96,23 +91,10 @@ describe('MockVM', () => {
     // this will backup the database
     MockVM.commitTransaction();
 
-    expect(() => {
-      System.requireAuthority(authority.authorization_type.contract_call, mockAccount);
-    }).not.toThrow();
-
-    expect(() => {
-      System.requireAuthority(authority.authorization_type.contract_upload, mockAccount2);
-    }).not.toThrow();
-
-    expect(() => {
-      // will print "account 1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe has not authorized action"
-      System.requireAuthority(authority.authorization_type.contract_upload, mockAccount);
-    }).toThrow();
-
-    expect(() => {
-      // will print "account 1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe has not authorized action"
-      System.requireAuthority(authority.authorization_type.transaction_application, mockAccount);
-    }).toThrow();
+    expect(System.checkAuthority(authority.authorization_type.contract_call, mockAccount)).toBe(true);
+    expect(System.checkAuthority(authority.authorization_type.contract_upload, mockAccount2)).toBe(true);
+    expect(System.checkAuthority(authority.authorization_type.contract_upload, mockAccount)).toBe(false);
+    expect(System.checkAuthority(authority.authorization_type.transaction_application, mockAccount)).toBe(false);
   });
 
   it('should set the call contract results', () => {
@@ -121,14 +103,14 @@ describe('MockVM', () => {
 
     MockVM.setCallContractResults([callRes1, callRes2]);
 
-    let callRes = System.callContract(mockAccount, 1, new Uint8Array(0));
+    let callRes = System.call(mockAccount, 1, new Uint8Array(0));
 
     expect(callRes).not.toBeNull();
-    expect(Arrays.equal(callRes, mockAccount)).toBe(true);
+    expect(Arrays.equal(callRes.value, mockAccount)).toBe(true);
 
-    callRes = System.callContract(mockAccount, 1, new Uint8Array(0));
+    callRes = System.call(mockAccount, 1, new Uint8Array(0));
     expect(callRes).not.toBeNull();
-    expect(Arrays.equal(callRes, mockAccount2)).toBe(true);
+    expect(Arrays.equal(callRes.value, mockAccount2)).toBe(true);
   });
 
   it('should reset the MockVM database', () => {

--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -13,9 +13,6 @@ describe('MockVM', () => {
 
     MockVM.setChainId(chainId)
 
-    log(chainId)
-    log(System.getChainId())
-
     expect(Arrays.equal(System.getChainId(), chainId)).toBe(true);
   });
 

--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -177,4 +177,11 @@ describe('MockVM', () => {
     System.log("log 3");
     expect(MockVM.getLogs()).toStrictEqual(["log 3"]);
   });
+
+  it("should handle error messages", () => {
+    const message = "my message";
+    System.putBytes(MockVM.METADATA_SPACE, 'error_message', StringBytes.stringToBytes(message));
+
+    expect(MockVM.getErrorMessage()).toBe(message)
+  });
 });

--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -8,6 +8,17 @@ const mockId = StringBytes.stringToBytes("0x12345");
 
 describe('MockVM', () => {
 
+  it('should get the chain id', () => {
+    const chainId = mockAccount;
+
+    MockVM.setChainId(chainId)
+
+    log(chainId)
+    log(System.getChainId())
+
+    expect(Arrays.equal(System.getChainId(), chainId)).toBe(true);
+  });
+
   it('should set the contract arguments', () => {
     const setEntryPoint = 0xc3ab8ff1;
     MockVM.setEntryPoint(0xc3ab8ff1);

--- a/__tests__/safeMath.spec.ts
+++ b/__tests__/safeMath.spec.ts
@@ -1,5 +1,5 @@
 import { u128 } from "as-bignum";
-import { MockVM, SafeMath } from "../assembly";
+import { MockVM, SafeMath, StringBytes } from "../assembly";
 
 describe('SafeMath', () => {
   beforeEach(() => {
@@ -133,15 +133,15 @@ describe('SafeMath', () => {
         SafeMath.add(a, b);
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('could not add 18446744073709551615 to 1');
+
       expect(() => {
         let a: u64 = u64.MAX_VALUE;
         let b: u64 = 1;
         SafeMath.add(b, a);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not add 18446744073709551615 to 1');
-      expect(logs[1]).toBe('could not add 1 to 18446744073709551615');
+      expect(MockVM.getErrorMessage()).toBe('could not add 1 to 18446744073709551615');
     });
 
     it('reverts on addition overflow - u128', () => {
@@ -151,15 +151,15 @@ describe('SafeMath', () => {
         SafeMath.add(a, b);
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('could not add');
+
       expect(() => {
         let a: u128 = u128.Max;
         let b: u128 = u128.One;
         SafeMath.add(b, a);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not add');
-      expect(logs[1]).toBe('could not add');
+      expect(MockVM.getErrorMessage()).toBe('could not add');
     });
 
     it('adds correctly if it does not overflow and the result is positive', () => {
@@ -189,15 +189,15 @@ describe('SafeMath', () => {
         SafeMath.add(a, b);
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('could not add 9223372036854775807 to 1');
+
       expect(() => {
         let a: i64 = i64.MAX_VALUE;
         let b: i64 = 1;
         SafeMath.add(b, a);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not add 9223372036854775807 to 1');
-      expect(logs[1]).toBe('could not add 1 to 9223372036854775807');
+      expect(MockVM.getErrorMessage()).toBe('could not add 1 to 9223372036854775807');
     });
 
     it('reverts on negative addition overflow', () => {
@@ -207,15 +207,15 @@ describe('SafeMath', () => {
         SafeMath.add(a, b);
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('could not add -9223372036854775808 to -1');
+
       expect(() => {
         let a: i64 = i64.MIN_VALUE;
         let b: i64 = -1;
         SafeMath.add(b, a);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not add -9223372036854775808 to -1');
-      expect(logs[1]).toBe('could not add -1 to -9223372036854775808');
+      expect(MockVM.getErrorMessage()).toBe('could not add -1 to -9223372036854775808');
     });
 
     it('reverts with a custom message', () => {
@@ -225,22 +225,23 @@ describe('SafeMath', () => {
         SafeMath.add(a, b, 'my message');
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('my message');
+
       expect(() => {
         let a: i64 = i64.MAX_VALUE;
         let b: i64 = 1;
         SafeMath.add(b, a, 'my message1');
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('my message1');
+
       expect(() => {
         let a: u128 = u128.Max;
         let b: u128 = u128.One;
-        SafeMath.add(b, a, 'my message1');
+        SafeMath.add(b, a, 'my message2');
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('my message');
-      expect(logs[1]).toBe('my message1');
-      expect(logs[2]).toBe('my message1');
+      expect(MockVM.getErrorMessage()).toBe('my message2');
     });
   });
 
@@ -336,8 +337,7 @@ describe('SafeMath', () => {
         SafeMath.sub(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not subtract 5678 from 1234');
+      expect(MockVM.getErrorMessage()).toBe('could not subtract 5678 from 1234');
     });
 
     it('reverts if subtraction result would be negative - u128', () => {
@@ -347,8 +347,7 @@ describe('SafeMath', () => {
         SafeMath.sub(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not subtract');
+      expect(MockVM.getErrorMessage()).toBe('could not subtract');
     });
 
     it('subtracts correctly if it does not overflow and the result is positive', () => {
@@ -372,8 +371,7 @@ describe('SafeMath', () => {
         SafeMath.sub(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not subtract -1 from 9223372036854775807');
+      expect(MockVM.getErrorMessage()).toBe('could not subtract -1 from 9223372036854775807');
     });
 
     it('reverts on negative subtraction overflow', () => {
@@ -383,8 +381,7 @@ describe('SafeMath', () => {
         SafeMath.sub(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not subtract 1 from -9223372036854775808');
+      expect(MockVM.getErrorMessage()).toBe('could not subtract 1 from -9223372036854775808');
     });
 
     it('reverts with a custom message', () => {
@@ -394,15 +391,15 @@ describe('SafeMath', () => {
         SafeMath.sub(a, b, 'my message');
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('my message');
+
       expect(() => {
         let a: u128 = u128.Min;
         let b: u128 = u128.One;
-        SafeMath.sub(a, b, 'my message');
+        SafeMath.sub(a, b, 'my message1');
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('my message');
-      expect(logs[1]).toBe('my message');
+      expect(MockVM.getErrorMessage()).toBe('my message1');
     });
   });
 
@@ -622,15 +619,15 @@ describe('SafeMath', () => {
         SafeMath.mul(a, b);
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('could not multiply');
+
       expect(() => {
         let a: u128 = u128.Max;
         let b: u128 = u128.from(2);
         SafeMath.mul(b, a);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not multiply');
-      expect(logs[1]).toBe('could not multiply');
+      expect(MockVM.getErrorMessage()).toBe('could not multiply');
     });
 
     it('reverts on multiplication overflow', () => {
@@ -640,15 +637,15 @@ describe('SafeMath', () => {
         SafeMath.mul(a, b);
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('could not multiply 9223372036854775807 by 2');
+
       expect(() => {
         let a: i64 = i64.MAX_VALUE;
         let b: i64 = 2;
         SafeMath.mul(b, a);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not multiply 9223372036854775807 by 2');
-      expect(logs[1]).toBe('could not multiply 2 by 9223372036854775807');
+      expect(MockVM.getErrorMessage()).toBe('could not multiply 2 by 9223372036854775807');
     });
 
     it('reverts on multiplication overflow with a custom message', () => {
@@ -658,15 +655,15 @@ describe('SafeMath', () => {
         SafeMath.mul(a, b, 'my message');
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('my message');
+
       expect(() => {
         let a: i64 = i64.MAX_VALUE;
         let b: i64 = 2;
         SafeMath.mul(b, a, 'my message1');
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('my message');
-      expect(logs[1]).toBe('my message1');
+      expect(MockVM.getErrorMessage()).toBe('my message1');
     });
   });
 
@@ -855,8 +852,7 @@ describe('SafeMath', () => {
         SafeMath.div(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not divide 5678 by 0');
+      expect(MockVM.getErrorMessage()).toBe('could not divide 5678 by 0');
     });
 
     it('reverts on division by zero - u128', () => {
@@ -866,8 +862,7 @@ describe('SafeMath', () => {
         SafeMath.div(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not divide');
+      expect(MockVM.getErrorMessage()).toBe('could not divide');
     });
 
     it('reverts on division by zero with a custom message', () => {
@@ -877,15 +872,15 @@ describe('SafeMath', () => {
         SafeMath.div(a, b, 'my message');
       }).toThrow();
 
+      expect(MockVM.getErrorMessage()).toBe('my message');
+
       expect(() => {
         let a: u128 = u128.Min;
         let b: u128 = u128.Zero;
-        SafeMath.div(a, b, 'my message');
+        SafeMath.div(a, b, 'my message1');
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('my message');
-      expect(logs[1]).toBe('my message');
+      expect(MockVM.getErrorMessage()).toBe('my message1');
     });
   });
 
@@ -1134,8 +1129,7 @@ describe('SafeMath', () => {
         SafeMath.mod(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not calulate 5678 modulo 0');
+      expect(MockVM.getErrorMessage()).toBe('could not calulate 5678 modulo 0');
     });
 
     it('reverts with a 0 divisor - u128', () => {
@@ -1145,8 +1139,7 @@ describe('SafeMath', () => {
         SafeMath.mod(a, b);
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('could not calulate modulo');
+      expect(MockVM.getErrorMessage()).toBe('could not calulate modulo');
     });
 
     it('reverts with a 0 divisor with a custom message', () => {
@@ -1156,8 +1149,7 @@ describe('SafeMath', () => {
         SafeMath.mod(a, b, 'my message');
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('my message');
+      expect(MockVM.getErrorMessage()).toBe('my message');
     });
 
     it('reverts with a 0 divisor with a custom message - u128', () => {
@@ -1167,8 +1159,7 @@ describe('SafeMath', () => {
         SafeMath.mod(a, b, 'my message');
       }).toThrow();
 
-      const logs = MockVM.getLogs();
-      expect(logs[0]).toBe('my message');
+      expect(MockVM.getErrorMessage()).toBe('my message');
     });
   });
 });

--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -14,6 +14,17 @@ describe('SystemCalls', () => {
     MockVM.reset();
   });
 
+  it('should get the chain id', () => {
+    const chainId = mockAccount;
+
+    MockVM.setChainId(chainId)
+
+    log(chainId)
+    log(System.getChainId())
+
+    expect(Arrays.equal(System.getChainId(), chainId)).toBe(true);
+  });
+
   it('should get the head info', () => {
     const setHeadInfo = new chain.head_info();
     setHeadInfo.head_block_time = 123456789;
@@ -266,17 +277,23 @@ describe('SystemCalls', () => {
       System.exit(0);
     }).toThrow();
 
-    let exitCode = MockVM.getExitCode();
+    expect(MockVM.getExitCode()).toBe(0);
 
-    expect(exitCode).toBe(0);
+    const message = "my message";
 
     expect(() => {
-      System.exit(1);
+      System.exit(1, StringBytes.stringToBytes(message));
     }).toThrow();
 
-    exitCode = MockVM.getExitCode();
+    expect(MockVM.getExitCode()).toBe(1);
+    expect(MockVM.getErrorMessage()).toBe(message);
 
-    expect(exitCode).toBe(1);
+    expect(() => {
+      System.revert(message);
+    })
+
+    expect(MockVM.getExitCode()).toBe(1);
+    expect(MockVM.getErrorMessage()).toBe(message);
   });
 
   it('should put and get bytes', () => {

--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -206,31 +206,27 @@ describe('SystemCalls', () => {
 
     MockVM.setCallContractResults([callRes1, callRes2]);
 
-    let callRes = System.callContract(mockAccount, 1, new Uint8Array(0));
 
-    expect(callRes).not.toBeNull();
-    expect(Arrays.equal(callRes, mockAccount)).toBe(true);
+    let callRes = System.call(mockAccount, 1, new Uint8Array(0));
 
-    callRes = System.callContract(mockAccount, 1, new Uint8Array(0));
-    expect(callRes).not.toBeNull();
-    expect(Arrays.equal(callRes, mockAccount2)).toBe(true);
-  });
+    expect(callRes.code).toBe(0);
+    expect(Arrays.equal(callRes.value, mockAccount)).toBe(true);
 
-  it('should get the entry point', () => {
-    const setEntryPoint = 0xc3ab8ff1;
-    MockVM.setEntryPoint(0xc3ab8ff1);
+    callRes = System.call(mockAccount, 1, new Uint8Array(0));
 
-    const getEntryPoint = System.getEntryPoint();
-
-    expect(getEntryPoint).toBe(setEntryPoint);
+    expect(callRes.code).toBe(0);
+    expect(Arrays.equal(callRes.value, mockAccount2)).toBe(true);
   });
 
   it('should get the contract arguments', () => {
+    const setEntryPoint = 0xc3ab8ff1;
+    MockVM.setEntryPoint(0xc3ab8ff1);
     MockVM.setContractArguments(mockAccount);
 
     const getContractArgs = System.getArguments();
 
-    expect(Arrays.equal(getContractArgs, mockAccount)).toBe(true);
+    expect(Arrays.equal(getContractArgs.args, mockAccount)).toBe(true);
+    expect(getContractArgs.entry_point).toBe(setEntryPoint)
   });
 
   it('should get the contract id', () => {
@@ -263,14 +259,6 @@ describe('SystemCalls', () => {
 
     expect(getCallerData.caller_privilege).toBe(setCallerData.caller_privilege);
     expect(Arrays.equal(getCallerData.caller, mockAccount)).toBe(true);
-  });
-
-  it('should set the contract result', () => {
-    System.setContractResult(mockStrBytes);
-
-    const contractRes = MockVM.getContractResult();
-
-    expect(Arrays.equal(contractRes, mockStrBytes)).toBe(true);
   });
 
   it('should exit a contract', () => {

--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -86,6 +86,18 @@ export namespace System {
     return env.invokeSystemCall(system_call_ids.system_call_id.apply_set_system_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
   }
 
+  export function getChainId(): Uint8Array {
+    const args = new system_calls.get_chain_id_arguments();
+    const encodedArgs = Protobuf.encode(args, system_calls.get_chain_id_arguments.encode);
+    const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
+    const returnBytes = new Uint32Array(1);
+
+    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_chain_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32)
+    const result = Protobuf.decode<system_calls.get_chain_id_result>(readBuffer, system_calls.get_chain_id_result.decode, returnBytes[0]);
+
+    return result.value!;
+  }
+
   // System Helpers
 
   export function processBlockSignature(digest: Uint8Array, header: protocol.block_header, signature: Uint8Array): bool {

--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -1,11 +1,16 @@
 import { env } from "./env";
 import { Protobuf, Reader, Writer } from 'as-proto';
-import { system_calls, system_call_ids, chain, protocol, authority, value, resources } from 'koinos-proto-as';
+import { system_calls, system_call_ids, chain, protocol, authority, value, error } from 'koinos-proto-as';
 import { StringBytes } from ".";
 
 export namespace System {
   export const DEFAULT_MAX_BUFFER_SIZE = 1024;
   export let MAX_BUFFER_SIZE = DEFAULT_MAX_BUFFER_SIZE;
+
+  function checkErrorCode(code: i32): void {
+    if (code != error.error_code.success)
+      revert("", code)
+  }
 
   // General Blockchain Management
 
@@ -26,7 +31,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_head_info, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_head_info, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_head_info_result>(readBuffer, system_calls.get_head_info_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -92,7 +98,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_chain_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32)
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_chain_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32)
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_chain_id_result>(readBuffer, system_calls.get_chain_id_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -106,7 +113,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.process_block_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.process_block_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.process_block_signature_result>(readBuffer, system_calls.process_block_signature_result.decode, returnBytes[0]);
 
     return result.value;
@@ -127,7 +135,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_transaction_result>(readBuffer, system_calls.get_transaction_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -151,7 +160,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_transaction_field_result>(readBuffer, system_calls.get_transaction_field_result.decode, returnBytes[0]);
 
     return result.value;
@@ -172,7 +182,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_block_result>(readBuffer, system_calls.get_block_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -198,7 +209,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_block_field_result>(readBuffer, system_calls.get_block_field_result.decode, returnBytes[0]);
 
     return result.value;
@@ -219,7 +231,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_last_irreversible_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_last_irreversible_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_last_irreversible_block_result>(readBuffer, system_calls.get_last_irreversible_block_result.decode, returnBytes[0]);
 
     return result.value;
@@ -231,7 +244,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_account_nonce_result>(readBuffer, system_calls.get_account_nonce_result.decode, returnBytes[0]);
 
     return result.value;
@@ -243,7 +257,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.verify_account_nonce_result>(readBuffer, system_calls.verify_account_nonce_result.decode, returnBytes[0]);
 
     return result.value;
@@ -256,7 +271,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
   }
 
   export function checkSystemAuthority(type: system_calls.system_authorization_type): bool {
@@ -265,7 +281,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    env.invokeSystemCall(system_call_ids.system_call_id.check_system_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.check_system_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     return Protobuf.decode<system_calls.check_system_authority_result>(readBuffer, system_calls.check_system_authority_result.decode).value;
   }
 
@@ -281,7 +298,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_account_rc_result>(readBuffer, system_calls.get_account_rc_result.decode, returnBytes[0]);
 
     return result.value;
@@ -293,7 +311,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.consume_account_rc_result>(readBuffer, system_calls.consume_account_rc_result.decode, returnBytes[0]);
 
     return result.value;
@@ -305,7 +324,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_resource_limits, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_resource_limits, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_resource_limits_result>(readBuffer, system_calls.get_resource_limits_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -317,7 +337,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_block_resources, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_block_resources, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.consume_block_resources_result>(readBuffer, system_calls.consume_block_resources_result.decode, returnBytes[0]);
 
     return result.value;
@@ -339,7 +360,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    env.invokeSystemCall(system_call_ids.system_call_id.log, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.log, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
   }
 
   /**
@@ -369,7 +391,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    env.invokeSystemCall(system_call_ids.system_call_id.event, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.event, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
   }
 
   // Cryptography
@@ -391,7 +414,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.hash, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.hash, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.hash_result>(readBuffer, system_calls.hash_result.decode, returnBytes[0]);
 
     return result.value;
@@ -419,7 +443,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.recover_public_key, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.recover_public_key, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.recover_public_key_result>(readBuffer, system_calls.recover_public_key_result.decode, returnBytes[0]);
 
     return result.value;
@@ -440,7 +465,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_merkle_root, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_merkle_root, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.verify_merkle_root_result>(readBuffer, system_calls.verify_merkle_root_result.decode, returnBytes[0]);
 
     return result.value;
@@ -465,7 +491,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.verify_signature_result>(readBuffer, system_calls.verify_signature_result.decode, returnBytes[0]);
 
     return result.value;
@@ -527,6 +554,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.call, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.call_result>(readBuffer, system_calls.call_result.decode, returnBytes[0]);
 
     return {code: retcode, value: (result.value) ? result.value! : new Uint8Array(0)};
@@ -558,7 +586,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_arguments, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_arguments, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_arguments_result>(readBuffer, system_calls.get_arguments_result.decode, returnBytes[0]);
 
     let ret = new getArgumentsReturn()
@@ -591,11 +620,12 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
   }
 
-  export function revert(msg: string = ""): void {
-    exit(1, StringBytes.stringToBytes(msg))
+  export function revert(msg: string = "", code: i32 = 1): void {
+    exit(code, StringBytes.stringToBytes(msg))
   }
 
   /**
@@ -613,7 +643,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_contract_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_contract_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_contract_id_result>(readBuffer, system_calls.get_contract_id_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -637,7 +668,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_caller, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_caller, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.get_caller_result>(readBuffer, system_calls.get_caller_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -660,7 +692,8 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.check_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.check_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
     const result = Protobuf.decode<system_calls.check_authority_result>(readBuffer, system_calls.check_authority_result.decode, returnBytes[0]);
     return result.value;
   }
@@ -729,7 +762,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const _retcode = env.invokeSystemCall(system_call_ids.system_call_id.put_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.put_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
   }
 
   /**
@@ -787,7 +821,8 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    env.invokeSystemCall(system_call_ids.system_call_id.remove_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.remove_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
   }
 
   /**
@@ -827,6 +862,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
 
     if (!returnBytes[0]) {
       return null;
@@ -913,6 +949,8 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_next_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
+
     if (retcode) {
       return null;
     }
@@ -987,6 +1025,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_prev_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    checkErrorCode(retcode);
 
     if (retcode) {
       return null;

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -69,6 +69,10 @@ export namespace MockVM {
     System.putBytes(METADATA_SPACE, 'contract_id', contractId);
   }
 
+  export function setChainId(chainId: Uint8Array): void {
+    System.putBytes(METADATA_SPACE, 'chain_id', chainId);
+  }
+
   /**
     * Set head info that will be used when calling System.getHeadInfo()
     * @param { chain.head_info } headInfo head info to set

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -283,8 +283,8 @@ export namespace MockVM {
     const bytes = System.getBytes(METADATA_SPACE, 'exit_code');
 
     if (bytes) {
-      const valueType =  Protobuf.decode<system_calls.exit_arguments>(bytes, system_calls.exit_arguments.decode);
-      return valueType.retval!.code;
+      const valueType = Protobuf.decode<value.value_type>(bytes, value.value_type.decode);
+      return valueType.int32_value;
     }
 
     return -1;

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -1,6 +1,7 @@
 import { Protobuf } from "as-proto";
 import { System } from "../systemCalls";
 import { system_calls, chain, protocol, authority, value } from 'koinos-proto-as';
+import { StringBytes } from "./stringBytes";
 
 
 export namespace MockVM {
@@ -246,7 +247,7 @@ export namespace MockVM {
   }
 
   /**
-    * Get contract result set when calling System.setContractRsult()
+    * Get contract result set when calling System.exit()
     * @returns { Uint8Array | null }
     * @example
     * ```ts
@@ -263,6 +264,20 @@ export namespace MockVM {
     const bytes = System.getBytes(METADATA_SPACE, 'contract_result');
 
     return bytes;
+  }
+
+  /**
+   * Get error message string after a VM error
+   * @returns  { Uint8Array | null }
+   * @example
+   * ```ts
+   * const errorMessage = MockVM.getErrorMessage();
+   * ```
+   */
+  export function getErrorMessage(): String | null {
+    const bytes = System.getBytes(METADATA_SPACE, 'error_message');
+
+    return StringBytes.bytesToString(bytes)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assemblyscript": "^0.19.22",
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
-    "koinos-mock-vm": "1.1.0",
+    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#json-descriptors-package",
     "koinos-proto-as": "https://github.com/koinos/koinos-proto-as.git#testnet-4",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assemblyscript": "^0.19.22",
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
-    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#json-descriptors-package",
+    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#testnet-4",
     "koinos-proto-as": "https://github.com/koinos/koinos-proto-as#testnet-4",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
     "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#json-descriptors-package",
-    "koinos-proto-as": "https://github.com/koinos/koinos-proto-as.git#testnet-4",
+    "koinos-proto-as": "https://github.com/koinos/koinos-proto-as#testnet-4",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",
     "typescript": "^4.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,14 +1454,14 @@ koinos-as-gen@0.4.8:
   dependencies:
     google-protobuf "^3.19.4"
 
-koinos-mock-vm@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/koinos-mock-vm/-/koinos-mock-vm-1.1.0.tgz#bd8d94c87bc0e592cf76819016eedbae189cbdc0"
-  integrity sha512-BC7nZkSaCRWKD4dKFwAP9h0bvs3Hrz6oy67+NAyK8RgGqfxAWYU5HwIire7xx7MZRReEHpKuJN5FzxijXNbUQQ==
+"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
+  version "1.1.1"
+  resolved "https://github.com/koinos/koinos-mock-vm#5f41c1e1885cdcb6d1f5768eeab22ecdfc2b4447"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"
     chalk "4.1.2"
+    koinos-proto-js "^0.0.2"
     multibase "^4.0.6"
     protobufjs "^6.11.2"
     somap "^0.5.14"
@@ -1471,6 +1471,11 @@ koinos-mock-vm@1.1.0:
   resolved "https://github.com/koinos/koinos-proto-as.git#bd481cdabbce13cc7d97c8f45e287428b03034bc"
   dependencies:
     as-proto "^0.2.2"
+
+koinos-proto-js@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/koinos-proto-js/-/koinos-proto-js-0.0.2.tgz#3a1c2091ee2bf067a9fb2715048c1e8aff9411ca"
+  integrity sha512-NhJUiHYgS5U7ZjUJ10LtAg8WKx1qo4veMHVycXywE5g/rEXEgC42RimPsQQkHhJjkniHMnzhKqPrZ5u/A0y/kw==
 
 levn@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,7 +1456,7 @@ koinos-as-gen@0.4.8:
 
 "koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#c09931a7e2e43068c8c270b7f093dc0a16e0e786"
+  resolved "https://github.com/koinos/koinos-mock-vm#ab78c3f78a0ed1483022e26a495b6938b269fbd1"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,7 +1456,7 @@ koinos-as-gen@0.4.8:
 
 "koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#c560c1add146706ec8e04a0a9bc441d8deeb2619"
+  resolved "https://github.com/koinos/koinos-mock-vm#c09931a7e2e43068c8c270b7f093dc0a16e0e786"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,7 +1456,7 @@ koinos-as-gen@0.4.8:
 
 "koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#710a9e7c7a6eca7e9fa515d1bf888f534c13b899"
+  resolved "https://github.com/koinos/koinos-mock-vm#a44c7e7e23e47b49b2a60998aa7987730f88fc36"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"
@@ -1466,9 +1466,9 @@ koinos-as-gen@0.4.8:
     protobufjs "^6.11.2"
     somap "^0.5.14"
 
-"koinos-proto-as@https://github.com/koinos/koinos-proto-as.git#testnet-4":
+"koinos-proto-as@https://github.com/koinos/koinos-proto-as#testnet-4":
   version "0.4.2"
-  resolved "https://github.com/koinos/koinos-proto-as.git#bd481cdabbce13cc7d97c8f45e287428b03034bc"
+  resolved "https://github.com/koinos/koinos-proto-as#b7ab54d83a8c7eb5d0f4379c5f1b738c1b3136df"
   dependencies:
     as-proto "^0.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,7 +1456,7 @@ koinos-as-gen@0.4.8:
 
 "koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#5f41c1e1885cdcb6d1f5768eeab22ecdfc2b4447"
+  resolved "https://github.com/koinos/koinos-mock-vm#c560c1add146706ec8e04a0a9bc441d8deeb2619"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,9 +1454,9 @@ koinos-as-gen@0.4.8:
   dependencies:
     google-protobuf "^3.19.4"
 
-"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
+"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#testnet-4":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#a44c7e7e23e47b49b2a60998aa7987730f88fc36"
+  resolved "https://github.com/koinos/koinos-mock-vm#b9176049af562c78efc83634b557d7b90733e0ab"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,12 +1456,12 @@ koinos-as-gen@0.4.8:
 
 "koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#fc81ab601ce42863705dba9f35d188ea10707437"
+  resolved "https://github.com/koinos/koinos-mock-vm#710a9e7c7a6eca7e9fa515d1bf888f534c13b899"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"
     chalk "4.1.2"
-    koinos-proto-js "^0.0.2"
+    koinos-proto-js "https://github.com/koinos/koinos-proto-js#gov-updates"
     multibase "^4.0.6"
     protobufjs "^6.11.2"
     somap "^0.5.14"
@@ -1472,10 +1472,9 @@ koinos-as-gen@0.4.8:
   dependencies:
     as-proto "^0.2.2"
 
-koinos-proto-js@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/koinos-proto-js/-/koinos-proto-js-0.0.2.tgz#3a1c2091ee2bf067a9fb2715048c1e8aff9411ca"
-  integrity sha512-NhJUiHYgS5U7ZjUJ10LtAg8WKx1qo4veMHVycXywE5g/rEXEgC42RimPsQQkHhJjkniHMnzhKqPrZ5u/A0y/kw==
+"koinos-proto-js@https://github.com/koinos/koinos-proto-js#gov-updates":
+  version "0.0.4"
+  resolved "https://github.com/koinos/koinos-proto-js#b3afb7a90031e1e4cfca286654c6578eea6f5c4f"
 
 levn@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,7 +1456,7 @@ koinos-as-gen@0.4.8:
 
 "koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#json-descriptors-package":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#ab78c3f78a0ed1483022e26a495b6938b269fbd1"
+  resolved "https://github.com/koinos/koinos-mock-vm#fc81ab601ce42863705dba9f35d188ea10707437"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"


### PR DESCRIPTION
Resolves #21
Resolves #22

## Brief description

Updates the SDK to be fully compatible with the new system call changes in `testnet-4` and uses up to date MockVM for passing unit tests.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
yarn test                           
yarn run v1.22.18
$ asp --verbose
       ___   _____                       __    
      /   | / ___/      ____  ___  _____/ /_   
     / /| | \__ \______/ __ \/ _ \/ ___/ __/   
    / ___ |___/ /_____/ /_/ /  __/ /__/ /_     
   /_/  |_/____/     / .___/\___/\___/\__/     
                    /_/                        

⚡AS-pect⚡ Test suite runner [6.2.4]

[Log] Loading asc compiler
Assemblyscript Folder:assemblyscript
[Log] Compiler loaded in 362.633ms.
[Log] Using configuration /Users/mdv/git/koinos-sdk-as/as-pect.config.js
[Log] Using VerboseReporter
[Log] Including files: /Users/mdv/git/koinos-sdk-as/__tests__/**/*.spec.ts
[Log] Running tests that match: (:?)
[Log] Running groups that match: (:?)
[Log] Effective command line args:
  [TestFile.ts] node_modules/@as-pect/assembly/assembly/index.ts --runtime incremental --debug --binaryFile output.wasm --explicitStart --use ASC_RTRACE=1 --exportTable --importMemory --transform /Users/mdv/git/koinos-sdk-as/node_modules/@as-covers/transform/lib/index.js,/Users/mdv/git/koinos-sdk-as/node_modules/@as-pect/core/lib/transform/index.js --lib node_modules/@as-covers/assembly/index.ts

[Describe]: MockVM

 [Success]: ✔ should get the chain id RTrace: +30
 [Success]: ✔ should set the contract arguments RTrace: +51
 [Success]: ✔ should set the contract id RTrace: +27
 [Success]: ✔ should set the head info RTrace: +36
 [Success]: ✔ should set the last irreversible block RTrace: +28
 [Success]: ✔ should set the caller RTrace: +38
 [Success]: ✔ should set the transaction RTrace: +39
 [Success]: ✔ should set the block RTrace: +35
 [Success]: ✔ should set the authorities RTrace: +96
 [Success]: ✔ should set the call contract results RTrace: +76
 [Success]: ✔ should reset the MockVM database RTrace: +71
 [Success]: ✔ should handle transactions RTrace: +191
[Log] log 1
[Log] log 2
[Log] log 3
 [Success]: ✔ should handle logs RTrace: +154
 [Success]: ✔ should handle error messages RTrace: +40

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/mockVM.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 14 pass,  0 fail, 14 total
    [Time]: 129.511ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: tryAdd

 [Success]: ✔ adds correctly RTrace: +30
 [Success]: ✔ adds correctly - u128 RTrace: +46
 [Success]: ✔ reverts on addition overflow RTrace: +30
 [Success]: ✔ reverts on addition overflow - u128 RTrace: +48
 [Success]: ✔ adds correctly if it does not overflow and the result is positive RTrace: +30
 [Success]: ✔ adds correctly if it does not overflow and the result is negative RTrace: +30
 [Success]: ✔ reverts on positive addition overflow RTrace: +30
 [Success]: ✔ reverts on negative addition overflow RTrace: +30

[Describe]: add

 [Success]: ✔ adds correctly RTrace: +16
 [Success]: ✔ adds correctly - u128 RTrace: +32
[Contract Exit] could not add 18446744073709551615 to 1
[Contract Exit] could not add 1 to 18446744073709551615
 [Success]: ✔ reverts on addition overflow RTrace: +98
[Contract Exit] could not add
[Contract Exit] could not add
 [Success]: ✔ reverts on addition overflow - u128 RTrace: +100
 [Success]: ✔ adds correctly if it does not overflow and the result is positive RTrace: +16
 [Success]: ✔ adds correctly if it does not overflow and the result is negative RTrace: +16
[Contract Exit] could not add 9223372036854775807 to 1
[Contract Exit] could not add 1 to 9223372036854775807
 [Success]: ✔ reverts on positive addition overflow RTrace: +98
[Contract Exit] could not add -9223372036854775808 to -1
[Contract Exit] could not add -1 to -9223372036854775808
 [Success]: ✔ reverts on negative addition overflow RTrace: +98
[Contract Exit] my message
[Contract Exit] my message1
[Contract Exit] my message2
 [Success]: ✔ reverts with a custom message RTrace: +142

[Describe]: trySub

 [Success]: ✔ subtracts correctly RTrace: +15
 [Success]: ✔ subtracts correctly - u128 RTrace: +24
 [Success]: ✔ reverts if subtraction result would be negative RTrace: +15
 [Success]: ✔ reverts if subtraction result would be negative - u128 RTrace: +24
 [Success]: ✔ subtracts correctly if it does not overflow and the result is positive RTrace: +15
 [Success]: ✔ subtracts correctly if it does not overflow and the result is negative RTrace: +15
 [Success]: ✔ reverts on positive subtraction overflow RTrace: +15
 [Success]: ✔ reverts on negative subtraction overflow RTrace: +15

[Describe]: sub

 [Success]: ✔ subtracts correctly RTrace: +8
 [Success]: ✔ subtracts correctly - u128 RTrace: +17
[Contract Exit] could not subtract 5678 from 1234
 [Success]: ✔ reverts if subtraction result would be negative RTrace: +49
[Contract Exit] could not subtract
 [Success]: ✔ reverts if subtraction result would be negative - u128 RTrace: +49
 [Success]: ✔ subtracts correctly if it does not overflow and the result is positive RTrace: +8
 [Success]: ✔ subtracts correctly if it does not overflow and the result is negative RTrace: +8
[Contract Exit] could not subtract -1 from 9223372036854775807
 [Success]: ✔ reverts on positive subtraction overflow RTrace: +49
[Contract Exit] could not subtract 1 from -9223372036854775808
 [Success]: ✔ reverts on negative subtraction overflow RTrace: +49
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts with a custom message RTrace: +95

[Describe]: tryMul

 [Success]: ✔ multiplies correctly RTrace: +30
 [Success]: ✔ multiplies correctly - u128 RTrace: +50
 [Success]: ✔ multiplies correctly - signed integers RTrace: +60
 [Success]: ✔ multiplies by zero correctly RTrace: +30
 [Success]: ✔ multiplies by zero correctly - u128 RTrace: +49
 [Success]: ✔ multiplies by zero correctly - signed integers RTrace: +30
 [Success]: ✔ reverts on multiplication overflow RTrace: +30
 [Success]: ✔ reverts on multiplication overflow - u128 RTrace: +832
 [Success]: ✔ reverts on multiplication overflow, positive operands RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i64 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i32 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i16 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i8 RTrace: +30

[Describe]: mul

 [Success]: ✔ multiplies correctly RTrace: +16
 [Success]: ✔ multiplies correctly - u128 RTrace: +36
 [Success]: ✔ multiplies by zero correctly RTrace: +16
 [Success]: ✔ multiplies by zero correctly - u128 RTrace: +35
[Contract Exit] could not multiply
[Contract Exit] could not multiply
 [Success]: ✔ reverts on multiplication overflow - u128 RTrace: +884
[Contract Exit] could not multiply 9223372036854775807 by 2
[Contract Exit] could not multiply 2 by 9223372036854775807
 [Success]: ✔ reverts on multiplication overflow RTrace: +98
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts on multiplication overflow with a custom message RTrace: +92

[Describe]: tryDiv

 [Success]: ✔ divides correctly RTrace: +15
 [Success]: ✔ divides correctly - u128 RTrace: +25
 [Success]: ✔ divides correctly - signed integers RTrace: +15
 [Success]: ✔ divides zero correctly RTrace: +15
 [Success]: ✔ divides zero correctly - u128 RTrace: +25
 [Success]: ✔ divides zero correctly - signed integers RTrace: +15
 [Success]: ✔ returns complete number result on non-even division RTrace: +15
 [Success]: ✔ returns complete number result on non-even division - u128 RTrace: +25
 [Success]: ✔ returns complete number result on non-even division - signed integers RTrace: +15
 [Success]: ✔ reverts on division by zero RTrace: +15
 [Success]: ✔ reverts on division by zero - u128 RTrace: +25
 [Success]: ✔ reverts on division by zero - signed integers RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i64 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i32 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i16 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i8 RTrace: +15

[Describe]: div

 [Success]: ✔ divides correctly RTrace: +8
 [Success]: ✔ divides correctly - u128 RTrace: +18
 [Success]: ✔ divides zero correctly RTrace: +8
 [Success]: ✔ divides zero correctly - u128 RTrace: +18
 [Success]: ✔ returns complete number result on non-even division RTrace: +8
 [Success]: ✔ returns complete number result on non-even division - u128 RTrace: +18
[Contract Exit] could not divide 5678 by 0
 [Success]: ✔ reverts on division by zero RTrace: +48
[Contract Exit] could not divide
 [Success]: ✔ reverts on division by zero - u128 RTrace: +50
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts on division by zero with a custom message RTrace: +96

[Describe]: trymod

[Describe]: modulos correctly

 [Success]: ✔ when the dividend is smaller than the divisor RTrace: +15
 [Success]: ✔ when the dividend is smaller than the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is smaller than the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is equal to the divisor RTrace: +15
 [Success]: ✔ when the dividend is equal to the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is equal to the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is larger than the divisor RTrace: +15
 [Success]: ✔ when the dividend is larger than the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is larger than the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is a multiple of the divisor RTrace: +15
 [Success]: ✔ when the dividend is a multiple of the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is a multiple of the divisor - signed integers RTrace: +15

 [Success]: ✔ reverts with a 0 divisor RTrace: +15
 [Success]: ✔ reverts with a 0 divisor - u128 RTrace: +25
 [Success]: ✔ reverts with a 0 divisor - signed integers RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i64 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i32 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i16 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i8 RTrace: +15

[Describe]: mod

[Describe]: modulos correctly

 [Success]: ✔ when the dividend is smaller than the divisor RTrace: +8
 [Success]: ✔ when the dividend is smaller than the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is equal to the divisor RTrace: +8
 [Success]: ✔ when the dividend is equal to the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is larger than the divisor RTrace: +8
 [Success]: ✔ when the dividend is larger than the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is a multiple of the divisor RTrace: +8
 [Success]: ✔ when the dividend is a multiple of the divisor - u128 RTrace: +18

[Contract Exit] could not calulate 5678 modulo 0
 [Success]: ✔ reverts with a 0 divisor RTrace: +48
[Contract Exit] could not calulate modulo
 [Success]: ✔ reverts with a 0 divisor - u128 RTrace: +50
[Contract Exit] my message
 [Success]: ✔ reverts with a 0 divisor with a custom message RTrace: +46
[Contract Exit] my message
 [Success]: ✔ reverts with a 0 divisor with a custom message - u128 RTrace: +50

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/safeMath.spec.ts
  [Groups]: 14 pass, 14 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 110 pass,  0 fail, 110 total
    [Time]: 457.183ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: space

 [Success]: ✔ should put and get an object RTrace: +48
 [Success]: ✔ should check if space has an object or not RTrace: +41
 [Success]: ✔ should remove an object RTrace: +51
 [Success]: ✔ should get next and prev object RTrace: +131
 [Success]: ✔ should get many RTrace: +688

[Describe]: space with proto key

 [Success]: ✔ should put and get an object RTrace: +44
 [Success]: ✔ should check if space has an object or not RTrace: +41
 [Success]: ✔ should remove an object RTrace: +49
 [Success]: ✔ should get next and prev object RTrace: +131
 [Success]: ✔ should get many RTrace: +483

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/space.spec.ts
  [Groups]: 3 pass, 3 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 10 pass,  0 fail, 10 total
    [Time]: 174.051ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: SystemCalls

 [Success]: ✔ should get the chain id RTrace: +27
 [Success]: ✔ should get the head info RTrace: +36
 [Success]: ✔ should get the transaction RTrace: +39
 [Success]: ✔ should get the transaction field RTrace: +35
 [Success]: ✔ should get the block RTrace: +35
 [Success]: ✔ should get the block field RTrace: +43
 [Success]: ✔ should get the last irreversible block RTrace: +28
[Contract Exit] 
[Contract Exit] 
 [Success]: ✔ should require authorities RTrace: +118
[Log] Hello World!
 [Success]: ✔ should log RTrace: +43
[Event] Hello World! / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe' ] / SGVsbG8gV29ybGQh
[Log] 1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe
 [Success]: ✔ should emit an event RTrace: +148
[Contract Exit] unknown hash code
 [Success]: ✔ should hash RTrace: +369
[Contract Exit] unexpected dsa
 [Success]: ✔ should recover a public key RTrace: +230
 [Success]: ✔ should verify a signature RTrace: +70
 [Success]: ✔ should should call a contract RTrace: +74
 [Success]: ✔ should get the contract arguments RTrace: +51
 [Success]: ✔ should get the contract id RTrace: +27
 [Success]: ✔ should get the head info RTrace: +36
 [Success]: ✔ should get the caller RTrace: +38
[Contract Result] 
[Contract Exit] 
[Contract Exit] my message
 [Success]: ✔ should exit a contract RTrace: +154
 [Success]: ✔ should put and get bytes RTrace: +313
 [Success]: ✔ should put and get objects RTrace: +202

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/systemCalls.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 21 pass,  0 fail, 21 total
    [Time]: 342.47ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: token

 [Success]: ✔ should get the name of a token RTrace: +55
 [Success]: ✔ should get the symbol of a token RTrace: +52
 [Success]: ✔ should get the decimals of a token RTrace: +45
 [Success]: ✔ should get the total supply of a token RTrace: +45
 [Success]: ✔ should get the balance of an account RTrace: +45
 [Success]: ✔ should/not tranfer a token RTrace: +88
 [Success]: ✔ should/not mint a token RTrace: +88
 [Success]: ✔ should/not burn a token RTrace: +88

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/token.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 8 pass,  0 fail, 8 total
    [Time]: 127.92ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: Base58

 [Success]: ✔ should decode a Base58 string into a Uint8Array RTrace: +209
 [Success]: ✔ should encode a Uint8Array into a Base58 string RTrace: +113

[Describe]: Base64

 [Success]: ✔ should decode a Base64 string into a Uint8Array RTrace: +69
 [Success]: ✔ should encode a Uint8Array into a Base64 string RTrace: +28

[Describe]: StringBytes

 [Success]: ✔ should convert a string into a Uint8Array RTrace: +22
 [Success]: ✔ should convert a Uint8Array into a string RTrace: +37

[Describe]: Crypto

 [Success]: ✔ should convert a public key into an address RTrace: +161
 [Success]: ✔ Multihash class RTrace: +134

[Describe]: Arrays

 [Success]: ✔ should compare two Uint8Array RTrace: +61
 [Success]: ✔ should convert hex strings RTrace: +188

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/util.spec.ts
  [Groups]: 6 pass, 6 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 10 pass,  0 fail, 10 total
    [Time]: 133.547ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [Result]: ✔ PASS
   [Files]: 6 total
  [Groups]: 29 count, 29 pass
   [Tests]: 173 pass, 0 fail, 173 total
    [Time]: 46045.305ms
┌──────────────────────────────┬───────┬───────┬───────┬───────┬──────────────────────────────────────────┐
│ File                         │ Total │ Block │ Func  │ Expr  │ Uncovered                                │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/systemCalls.ts      │ 65.9% │ 66.2% │ 64%   │ 75%   │ 12:7, 41:58, 41:3, 50:76, 50:3, 59:93... │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/base64.ts      │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/base58.ts      │ 95%   │ 92.3% │ 100%  │ 100%  │ 68:40                                    │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/stringBytes.ts │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/crypto.ts      │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/arrays.ts      │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/safeMath.ts    │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/mockVM.ts      │ 95%   │ 95.7% │ 94.1% │ N/A   │ 267:58, 267:3                            │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/token.ts       │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/space.ts       │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ total                        │ 89.6% │ 89.2% │ 85.4% │ 97.5% │                                          │
└──────────────────────────────┴───────┴───────┴───────┴───────┴──────────────────────────────────────────┘

✨  Done in 46.53s.
```
