### PR TITLE
Improve error handling

### DIFF
--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -7,9 +7,11 @@ export namespace System {
   export const DEFAULT_MAX_BUFFER_SIZE = 1024;
   export let MAX_BUFFER_SIZE = DEFAULT_MAX_BUFFER_SIZE;
 
-  function checkErrorCode(code: i32): void {
+  let ERROR_MESSAGE = ""
+
+  function checkErrorCode(code: i32, message: Uint8Array): void {
     if (code != error.error_code.success)
-      revert("", code)
+      exit(code, message)
   }
 
   // General Blockchain Management
@@ -32,7 +34,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_head_info, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_head_info_result>(readBuffer, system_calls.get_head_info_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -44,7 +46,9 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    return env.invokeSystemCall(system_call_ids.system_call_id.apply_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    return retcode;
   }
 
   export function applyTransaction(transaction: protocol.transaction): i32 {
@@ -53,7 +57,9 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    return env.invokeSystemCall(system_call_ids.system_call_id.apply_transaction, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_transaction, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    return retcode;
   }
 
   export function applyUploadContractOperation(op: protocol.upload_contract_operation): i32 {
@@ -62,7 +68,9 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    return env.invokeSystemCall(system_call_ids.system_call_id.apply_upload_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_upload_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    return retcode;
   }
 
   export function applyCallContractOperation(op: protocol.call_contract_operation): i32 {
@@ -71,7 +79,9 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    return env.invokeSystemCall(system_call_ids.system_call_id.apply_call_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_call_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    return retcode;
   }
 
   export function applySetSystemCallOperation(op: protocol.set_system_call_operation): i32 {
@@ -80,7 +90,9 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    return env.invokeSystemCall(system_call_ids.system_call_id.apply_set_system_call_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_set_system_call_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    return retcode;
   }
 
   export function applySetSystemContractOperation(op: protocol.set_system_contract_operation): i32 {
@@ -89,7 +101,9 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    return env.invokeSystemCall(system_call_ids.system_call_id.apply_set_system_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_set_system_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    return retcode;
   }
 
   export function getChainId(): Uint8Array {
@@ -99,7 +113,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_chain_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32)
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_chain_id_result>(readBuffer, system_calls.get_chain_id_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -114,7 +128,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.process_block_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.process_block_signature_result>(readBuffer, system_calls.process_block_signature_result.decode, returnBytes[0]);
 
     return result.value;
@@ -136,7 +150,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_transaction_result>(readBuffer, system_calls.get_transaction_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -161,7 +175,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_transaction_field_result>(readBuffer, system_calls.get_transaction_field_result.decode, returnBytes[0]);
 
     return result.value;
@@ -183,7 +197,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_block_result>(readBuffer, system_calls.get_block_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -210,7 +224,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_block_field_result>(readBuffer, system_calls.get_block_field_result.decode, returnBytes[0]);
 
     return result.value;
@@ -232,7 +246,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_last_irreversible_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_last_irreversible_block_result>(readBuffer, system_calls.get_last_irreversible_block_result.decode, returnBytes[0]);
 
     return result.value;
@@ -245,7 +259,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_account_nonce_result>(readBuffer, system_calls.get_account_nonce_result.decode, returnBytes[0]);
 
     return result.value;
@@ -258,7 +272,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.verify_account_nonce_result>(readBuffer, system_calls.verify_account_nonce_result.decode, returnBytes[0]);
 
     return result.value;
@@ -272,7 +286,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
   }
 
   export function checkSystemAuthority(type: system_calls.system_authorization_type): bool {
@@ -282,7 +296,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.check_system_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     return Protobuf.decode<system_calls.check_system_authority_result>(readBuffer, system_calls.check_system_authority_result.decode).value;
   }
 
@@ -299,7 +313,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_account_rc_result>(readBuffer, system_calls.get_account_rc_result.decode, returnBytes[0]);
 
     return result.value;
@@ -312,7 +326,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.consume_account_rc_result>(readBuffer, system_calls.consume_account_rc_result.decode, returnBytes[0]);
 
     return result.value;
@@ -325,7 +339,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_resource_limits, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_resource_limits_result>(readBuffer, system_calls.get_resource_limits_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -338,7 +352,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_block_resources, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.consume_block_resources_result>(readBuffer, system_calls.consume_block_resources_result.decode, returnBytes[0]);
 
     return result.value;
@@ -361,7 +375,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.log, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
   }
 
   /**
@@ -392,7 +406,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.event, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
   }
 
   // Cryptography
@@ -415,7 +429,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.hash, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.hash_result>(readBuffer, system_calls.hash_result.decode, returnBytes[0]);
 
     return result.value;
@@ -444,7 +458,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.recover_public_key, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.recover_public_key_result>(readBuffer, system_calls.recover_public_key_result.decode, returnBytes[0]);
 
     return result.value;
@@ -466,7 +480,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_merkle_root, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.verify_merkle_root_result>(readBuffer, system_calls.verify_merkle_root_result.decode, returnBytes[0]);
 
     return result.value;
@@ -492,7 +506,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.verify_signature_result>(readBuffer, system_calls.verify_signature_result.decode, returnBytes[0]);
 
     return result.value;
@@ -554,7 +568,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.call, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.call_result>(readBuffer, system_calls.call_result.decode, returnBytes[0]);
 
     return {code: retcode, value: (result.value) ? result.value! : new Uint8Array(0)};
@@ -587,7 +601,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_arguments, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_arguments_result>(readBuffer, system_calls.get_arguments_result.decode, returnBytes[0]);
 
     let ret = new getArgumentsReturn()
@@ -621,11 +635,33 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
   }
 
-  export function revert(msg: string = "", code: i32 = 1): void {
-    exit(code, StringBytes.stringToBytes(msg))
+  /**
+   * Revert the transaction in progress
+   * @param message Optional reversion message
+   * @param code Optional error code, must be >= 1, else code 1 is used (reverted exit code)
+   * ```ts
+   * if (!System.checkAuthority(authority.authorization_type.transaction_application, Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe)))
+   *   System.revert("contract is not authorized");
+   * ```
+   */
+  export function revert(message: string = "", code: i32 = 1): void {
+    exit(code >= error.error_code.reverted ? code : error.error_code.reverted, StringBytes.stringToBytes(message))
+  }
+
+  /**
+   * Gets a stored error message after a system call that can return an error.
+   * @returns string
+   * @example
+   * ```ts
+   * if (System.applyTransaction(trx) != error.error_code.success)
+   *   System.log(getErrorMessage())
+   * ```
+   */
+  export function getErrorMessage(): string {
+    return ERROR_MESSAGE;
   }
 
   /**
@@ -644,7 +680,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_contract_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_contract_id_result>(readBuffer, system_calls.get_contract_id_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -669,7 +705,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_caller, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.get_caller_result>(readBuffer, system_calls.get_caller_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -693,7 +729,7 @@ export namespace System {
 
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.check_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
     const result = Protobuf.decode<system_calls.check_authority_result>(readBuffer, system_calls.check_authority_result.decode, returnBytes[0]);
     return result.value;
   }
@@ -763,7 +799,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.put_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
   }
 
   /**
@@ -822,7 +858,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.remove_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
   }
 
   /**
@@ -862,7 +898,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
 
     if (!returnBytes[0]) {
       return null;
@@ -949,7 +985,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_next_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
 
     if (retcode) {
       return null;
@@ -1025,7 +1061,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_prev_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode);
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
 
     if (retcode) {
       return null;

--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -34,7 +34,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_head_info, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_head_info_result>(readBuffer, system_calls.get_head_info_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -47,7 +47,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0]))!;
     return retcode;
   }
 
@@ -58,7 +58,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_transaction, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0]))!;
     return retcode;
   }
 
@@ -69,7 +69,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_upload_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0]))!;
     return retcode;
   }
 
@@ -80,7 +80,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_call_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0]))!;
     return retcode;
   }
 
@@ -91,7 +91,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_set_system_call_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0]))!;
     return retcode;
   }
 
@@ -102,7 +102,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.apply_set_system_contract_operation, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0] - 1))!;
+    ERROR_MESSAGE = StringBytes.bytesToString(readBuffer.slice(0, returnBytes[0]))!;
     return retcode;
   }
 
@@ -113,7 +113,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_chain_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32)
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_chain_id_result>(readBuffer, system_calls.get_chain_id_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -128,7 +128,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.process_block_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.process_block_signature_result>(readBuffer, system_calls.process_block_signature_result.decode, returnBytes[0]);
 
     return result.value;
@@ -150,7 +150,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_transaction_result>(readBuffer, system_calls.get_transaction_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -175,7 +175,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_transaction_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_transaction_field_result>(readBuffer, system_calls.get_transaction_field_result.decode, returnBytes[0]);
 
     return result.value;
@@ -197,7 +197,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_block_result>(readBuffer, system_calls.get_block_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -224,7 +224,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_block_field, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_block_field_result>(readBuffer, system_calls.get_block_field_result.decode, returnBytes[0]);
 
     return result.value;
@@ -246,7 +246,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_last_irreversible_block, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_last_irreversible_block_result>(readBuffer, system_calls.get_last_irreversible_block_result.decode, returnBytes[0]);
 
     return result.value;
@@ -259,7 +259,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_account_nonce_result>(readBuffer, system_calls.get_account_nonce_result.decode, returnBytes[0]);
 
     return result.value;
@@ -272,7 +272,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.verify_account_nonce_result>(readBuffer, system_calls.verify_account_nonce_result.decode, returnBytes[0]);
 
     return result.value;
@@ -286,7 +286,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_account_nonce, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
   }
 
   export function checkSystemAuthority(type: system_calls.system_authorization_type): bool {
@@ -296,7 +296,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.check_system_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     return Protobuf.decode<system_calls.check_system_authority_result>(readBuffer, system_calls.check_system_authority_result.decode).value;
   }
 
@@ -313,7 +313,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_account_rc_result>(readBuffer, system_calls.get_account_rc_result.decode, returnBytes[0]);
 
     return result.value;
@@ -326,7 +326,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_account_rc, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.consume_account_rc_result>(readBuffer, system_calls.consume_account_rc_result.decode, returnBytes[0]);
 
     return result.value;
@@ -339,7 +339,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_resource_limits, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_resource_limits_result>(readBuffer, system_calls.get_resource_limits_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -352,7 +352,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.consume_block_resources, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.consume_block_resources_result>(readBuffer, system_calls.consume_block_resources_result.decode, returnBytes[0]);
 
     return result.value;
@@ -375,7 +375,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.log, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
   }
 
   /**
@@ -406,7 +406,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.event, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
   }
 
   // Cryptography
@@ -429,7 +429,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.hash, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.hash_result>(readBuffer, system_calls.hash_result.decode, returnBytes[0]);
 
     return result.value;
@@ -458,7 +458,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.recover_public_key, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.recover_public_key_result>(readBuffer, system_calls.recover_public_key_result.decode, returnBytes[0]);
 
     return result.value;
@@ -480,7 +480,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_merkle_root, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.verify_merkle_root_result>(readBuffer, system_calls.verify_merkle_root_result.decode, returnBytes[0]);
 
     return result.value;
@@ -506,7 +506,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_signature, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.verify_signature_result>(readBuffer, system_calls.verify_signature_result.decode, returnBytes[0]);
 
     return result.value;
@@ -568,7 +568,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.call, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.call_result>(readBuffer, system_calls.call_result.decode, returnBytes[0]);
 
     return {code: retcode, value: (result.value) ? result.value! : new Uint8Array(0)};
@@ -601,7 +601,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_arguments, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_arguments_result>(readBuffer, system_calls.get_arguments_result.decode, returnBytes[0]);
 
     let ret = new getArgumentsReturn()
@@ -635,7 +635,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
   }
 
   /**
@@ -680,7 +680,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_contract_id, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_contract_id_result>(readBuffer, system_calls.get_contract_id_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -705,7 +705,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_caller, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.get_caller_result>(readBuffer, system_calls.get_caller_result.decode, returnBytes[0]);
 
     return result.value!;
@@ -729,7 +729,7 @@ export namespace System {
 
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.check_authority, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
     const result = Protobuf.decode<system_calls.check_authority_result>(readBuffer, system_calls.check_authority_result.decode, returnBytes[0]);
     return result.value;
   }
@@ -799,7 +799,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.put_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
   }
 
   /**
@@ -858,7 +858,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.remove_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
   }
 
   /**
@@ -898,7 +898,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
 
     if (!returnBytes[0]) {
       return null;
@@ -985,7 +985,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_next_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
 
     if (retcode) {
       return null;
@@ -1061,7 +1061,7 @@ export namespace System {
     const returnBytes = new Uint32Array(1);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_prev_object, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0] - 1));
+    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
 
     if (retcode) {
       return null;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assemblyscript": "^0.19.22",
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
-    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#testnet-4",
+    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#improve-error-handling",
     "koinos-proto-as": "https://github.com/koinos/koinos-proto-as#testnet-4",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assemblyscript": "^0.19.22",
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
-    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#improve-error-handling",
+    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#testnet-4",
     "koinos-proto-as": "https://github.com/koinos/koinos-proto-as#testnet-4",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,9 +1454,9 @@ koinos-as-gen@0.4.8:
   dependencies:
     google-protobuf "^3.19.4"
 
-"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#testnet-4":
+"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#improve-error-handling":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#b9176049af562c78efc83634b557d7b90733e0ab"
+  resolved "https://github.com/koinos/koinos-mock-vm#7978df3a941b8767bbf0ff28ee9072791a29000b"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,9 +1454,9 @@ koinos-as-gen@0.4.8:
   dependencies:
     google-protobuf "^3.19.4"
 
-"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#improve-error-handling":
+"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#testnet-4":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#7978df3a941b8767bbf0ff28ee9072791a29000b"
+  resolved "https://github.com/koinos/koinos-mock-vm#ea864f05dd6e72605a31f52201883423c3bd8289"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"


### PR DESCRIPTION
Resolves koinos/koinos-chain#672

## Brief description

Handle error messages written to return buffer.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
yarn run v1.22.18
$ asp --verbose
       ___   _____                       __    
      /   | / ___/      ____  ___  _____/ /_   
     / /| | \__ \______/ __ \/ _ \/ ___/ __/   
    / ___ |___/ /_____/ /_/ /  __/ /__/ /_     
   /_/  |_/____/     / .___/\___/\___/\__/     
                    /_/                        

⚡AS-pect⚡ Test suite runner [6.2.4]

[Log] Loading asc compiler
Assemblyscript Folder:assemblyscript
[Log] Compiler loaded in 354.592ms.
[Log] Using configuration /Users/mdv/git/koinos-sdk-as/as-pect.config.js
[Log] Using VerboseReporter
[Log] Including files: /Users/mdv/git/koinos-sdk-as/__tests__/**/*.spec.ts
[Log] Running tests that match: (:?)
[Log] Running groups that match: (:?)
[Log] Effective command line args:
  [TestFile.ts] node_modules/@as-pect/assembly/assembly/index.ts --runtime incremental --debug --binaryFile output.wasm --explicitStart --use ASC_RTRACE=1 --exportTable --importMemory --transform /Users/mdv/git/koinos-sdk-as/node_modules/@as-covers/transform/lib/index.js,/Users/mdv/git/koinos-sdk-as/node_modules/@as-pect/core/lib/transform/index.js --lib node_modules/@as-covers/assembly/index.ts

[Describe]: MockVM

 [Success]: ✔ should get the chain id RTrace: +34
 [Success]: ✔ should set the contract arguments RTrace: +57
 [Success]: ✔ should set the contract id RTrace: +31
 [Success]: ✔ should set the head info RTrace: +40
 [Success]: ✔ should set the last irreversible block RTrace: +32
 [Success]: ✔ should set the caller RTrace: +42
 [Success]: ✔ should set the transaction RTrace: +43
 [Success]: ✔ should set the block RTrace: +39
 [Success]: ✔ should set the authorities RTrace: +108
 [Success]: ✔ should set the call contract results RTrace: +82
 [Success]: ✔ should reset the MockVM database RTrace: +79
 [Success]: ✔ should handle transactions RTrace: +215
[Log] log 1
[Log] log 2
[Log] log 3
 [Success]: ✔ should handle logs RTrace: +168
 [Success]: ✔ should handle error messages RTrace: +44

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/mockVM.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 14 pass,  0 fail, 14 total
    [Time]: 130.859ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: tryAdd

 [Success]: ✔ adds correctly RTrace: +30
 [Success]: ✔ adds correctly - u128 RTrace: +46
 [Success]: ✔ reverts on addition overflow RTrace: +30
 [Success]: ✔ reverts on addition overflow - u128 RTrace: +48
 [Success]: ✔ adds correctly if it does not overflow and the result is positive RTrace: +30
 [Success]: ✔ adds correctly if it does not overflow and the result is negative RTrace: +30
 [Success]: ✔ reverts on positive addition overflow RTrace: +30
 [Success]: ✔ reverts on negative addition overflow RTrace: +30

[Describe]: add

 [Success]: ✔ adds correctly RTrace: +16
 [Success]: ✔ adds correctly - u128 RTrace: +32
[Contract Exit] could not add 18446744073709551615 to 1
[Contract Exit] could not add 1 to 18446744073709551615
 [Success]: ✔ reverts on addition overflow RTrace: +102
[Contract Exit] could not add
[Contract Exit] could not add
 [Success]: ✔ reverts on addition overflow - u128 RTrace: +104
 [Success]: ✔ adds correctly if it does not overflow and the result is positive RTrace: +16
 [Success]: ✔ adds correctly if it does not overflow and the result is negative RTrace: +16
[Contract Exit] could not add 9223372036854775807 to 1
[Contract Exit] could not add 1 to 9223372036854775807
 [Success]: ✔ reverts on positive addition overflow RTrace: +102
[Contract Exit] could not add -9223372036854775808 to -1
[Contract Exit] could not add -1 to -9223372036854775808
 [Success]: ✔ reverts on negative addition overflow RTrace: +102
[Contract Exit] my message
[Contract Exit] my message1
[Contract Exit] my message2
 [Success]: ✔ reverts with a custom message RTrace: +148

[Describe]: trySub

 [Success]: ✔ subtracts correctly RTrace: +15
 [Success]: ✔ subtracts correctly - u128 RTrace: +24
 [Success]: ✔ reverts if subtraction result would be negative RTrace: +15
 [Success]: ✔ reverts if subtraction result would be negative - u128 RTrace: +24
 [Success]: ✔ subtracts correctly if it does not overflow and the result is positive RTrace: +15
 [Success]: ✔ subtracts correctly if it does not overflow and the result is negative RTrace: +15
 [Success]: ✔ reverts on positive subtraction overflow RTrace: +15
 [Success]: ✔ reverts on negative subtraction overflow RTrace: +15

[Describe]: sub

 [Success]: ✔ subtracts correctly RTrace: +8
 [Success]: ✔ subtracts correctly - u128 RTrace: +17
[Contract Exit] could not subtract 5678 from 1234
 [Success]: ✔ reverts if subtraction result would be negative RTrace: +51
[Contract Exit] could not subtract
 [Success]: ✔ reverts if subtraction result would be negative - u128 RTrace: +51
 [Success]: ✔ subtracts correctly if it does not overflow and the result is positive RTrace: +8
 [Success]: ✔ subtracts correctly if it does not overflow and the result is negative RTrace: +8
[Contract Exit] could not subtract -1 from 9223372036854775807
 [Success]: ✔ reverts on positive subtraction overflow RTrace: +51
[Contract Exit] could not subtract 1 from -9223372036854775808
 [Success]: ✔ reverts on negative subtraction overflow RTrace: +51
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts with a custom message RTrace: +99

[Describe]: tryMul

 [Success]: ✔ multiplies correctly RTrace: +30
 [Success]: ✔ multiplies correctly - u128 RTrace: +50
 [Success]: ✔ multiplies correctly - signed integers RTrace: +60
 [Success]: ✔ multiplies by zero correctly RTrace: +30
 [Success]: ✔ multiplies by zero correctly - u128 RTrace: +49
 [Success]: ✔ multiplies by zero correctly - signed integers RTrace: +30
 [Success]: ✔ reverts on multiplication overflow RTrace: +30
 [Success]: ✔ reverts on multiplication overflow - u128 RTrace: +832
 [Success]: ✔ reverts on multiplication overflow, positive operands RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i64 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i32 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i16 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i8 RTrace: +30

[Describe]: mul

 [Success]: ✔ multiplies correctly RTrace: +16
 [Success]: ✔ multiplies correctly - u128 RTrace: +36
 [Success]: ✔ multiplies by zero correctly RTrace: +16
 [Success]: ✔ multiplies by zero correctly - u128 RTrace: +35
[Contract Exit] could not multiply
[Contract Exit] could not multiply
 [Success]: ✔ reverts on multiplication overflow - u128 RTrace: +888
[Contract Exit] could not multiply 9223372036854775807 by 2
[Contract Exit] could not multiply 2 by 9223372036854775807
 [Success]: ✔ reverts on multiplication overflow RTrace: +102
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts on multiplication overflow with a custom message RTrace: +96

[Describe]: tryDiv

 [Success]: ✔ divides correctly RTrace: +15
 [Success]: ✔ divides correctly - u128 RTrace: +25
 [Success]: ✔ divides correctly - signed integers RTrace: +15
 [Success]: ✔ divides zero correctly RTrace: +15
 [Success]: ✔ divides zero correctly - u128 RTrace: +25
 [Success]: ✔ divides zero correctly - signed integers RTrace: +15
 [Success]: ✔ returns complete number result on non-even division RTrace: +15
 [Success]: ✔ returns complete number result on non-even division - u128 RTrace: +25
 [Success]: ✔ returns complete number result on non-even division - signed integers RTrace: +15
 [Success]: ✔ reverts on division by zero RTrace: +15
 [Success]: ✔ reverts on division by zero - u128 RTrace: +25
 [Success]: ✔ reverts on division by zero - signed integers RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i64 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i32 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i16 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i8 RTrace: +15

[Describe]: div

 [Success]: ✔ divides correctly RTrace: +8
 [Success]: ✔ divides correctly - u128 RTrace: +18
 [Success]: ✔ divides zero correctly RTrace: +8
 [Success]: ✔ divides zero correctly - u128 RTrace: +18
 [Success]: ✔ returns complete number result on non-even division RTrace: +8
 [Success]: ✔ returns complete number result on non-even division - u128 RTrace: +18
[Contract Exit] could not divide 5678 by 0
 [Success]: ✔ reverts on division by zero RTrace: +50
[Contract Exit] could not divide
 [Success]: ✔ reverts on division by zero - u128 RTrace: +52
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts on division by zero with a custom message RTrace: +100

[Describe]: trymod

[Describe]: modulos correctly

 [Success]: ✔ when the dividend is smaller than the divisor RTrace: +15
 [Success]: ✔ when the dividend is smaller than the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is smaller than the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is equal to the divisor RTrace: +15
 [Success]: ✔ when the dividend is equal to the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is equal to the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is larger than the divisor RTrace: +15
 [Success]: ✔ when the dividend is larger than the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is larger than the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is a multiple of the divisor RTrace: +15
 [Success]: ✔ when the dividend is a multiple of the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is a multiple of the divisor - signed integers RTrace: +15

 [Success]: ✔ reverts with a 0 divisor RTrace: +15
 [Success]: ✔ reverts with a 0 divisor - u128 RTrace: +25
 [Success]: ✔ reverts with a 0 divisor - signed integers RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i64 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i32 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i16 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i8 RTrace: +15

[Describe]: mod

[Describe]: modulos correctly

 [Success]: ✔ when the dividend is smaller than the divisor RTrace: +8
 [Success]: ✔ when the dividend is smaller than the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is equal to the divisor RTrace: +8
 [Success]: ✔ when the dividend is equal to the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is larger than the divisor RTrace: +8
 [Success]: ✔ when the dividend is larger than the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is a multiple of the divisor RTrace: +8
 [Success]: ✔ when the dividend is a multiple of the divisor - u128 RTrace: +18

[Contract Exit] could not calulate 5678 modulo 0
 [Success]: ✔ reverts with a 0 divisor RTrace: +50
[Contract Exit] could not calulate modulo
 [Success]: ✔ reverts with a 0 divisor - u128 RTrace: +52
[Contract Exit] my message
 [Success]: ✔ reverts with a 0 divisor with a custom message RTrace: +48
[Contract Exit] my message
 [Success]: ✔ reverts with a 0 divisor with a custom message - u128 RTrace: +52

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/safeMath.spec.ts
  [Groups]: 14 pass, 14 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 110 pass,  0 fail, 110 total
    [Time]: 473.802ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: space

 [Success]: ✔ should put and get an object RTrace: +52
 [Success]: ✔ should check if space has an object or not RTrace: +45
 [Success]: ✔ should remove an object RTrace: +57
 [Success]: ✔ should get next and prev object RTrace: +141
 [Success]: ✔ should get many RTrace: +738

[Describe]: space with proto key

 [Success]: ✔ should put and get an object RTrace: +48
 [Success]: ✔ should check if space has an object or not RTrace: +45
 [Success]: ✔ should remove an object RTrace: +55
 [Success]: ✔ should get next and prev object RTrace: +141
 [Success]: ✔ should get many RTrace: +521

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/space.spec.ts
  [Groups]: 3 pass, 3 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 10 pass,  0 fail, 10 total
    [Time]: 165.849ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: SystemCalls

 [Success]: ✔ should get the chain id RTrace: +31
 [Success]: ✔ should get the head info RTrace: +40
 [Success]: ✔ should get the transaction RTrace: +43
 [Success]: ✔ should get the transaction field RTrace: +39
 [Success]: ✔ should get the block RTrace: +39
 [Success]: ✔ should get the block field RTrace: +47
 [Success]: ✔ should get the last irreversible block RTrace: +32
[Contract Exit] 
[Contract Exit] 
 [Success]: ✔ should require authorities RTrace: +130
[Log] Hello World!
 [Success]: ✔ should log RTrace: +47
[Event] Hello World! / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe' ] / SGVsbG8gV29ybGQh
[Log] 1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe
 [Success]: ✔ should emit an event RTrace: +154
[Contract Exit] unknown hash code
 [Success]: ✔ should hash RTrace: +381
[Contract Exit] unexpected dsa
 [Success]: ✔ should recover a public key RTrace: +246
 [Success]: ✔ should verify a signature RTrace: +80
 [Success]: ✔ should should call a contract RTrace: +80
 [Success]: ✔ should get the contract arguments RTrace: +57
 [Success]: ✔ should get the contract id RTrace: +31
 [Success]: ✔ should get the head info RTrace: +40
 [Success]: ✔ should get the caller RTrace: +42
[Contract Result] 
[Contract Exit] 
[Contract Exit] my message
 [Success]: ✔ should exit a contract RTrace: +164
 [Success]: ✔ should put and get bytes RTrace: +337
 [Success]: ✔ should put and get objects RTrace: +218

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/systemCalls.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 21 pass,  0 fail, 21 total
    [Time]: 289.473ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: token

 [Success]: ✔ should get the name of a token RTrace: +59
 [Success]: ✔ should get the symbol of a token RTrace: +56
 [Success]: ✔ should get the decimals of a token RTrace: +49
 [Success]: ✔ should get the total supply of a token RTrace: +49
 [Success]: ✔ should get the balance of an account RTrace: +49
 [Success]: ✔ should/not tranfer a token RTrace: +96
 [Success]: ✔ should/not mint a token RTrace: +96
 [Success]: ✔ should/not burn a token RTrace: +96

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/token.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 8 pass,  0 fail, 8 total
    [Time]: 94.592ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: Base58

 [Success]: ✔ should decode a Base58 string into a Uint8Array RTrace: +209
 [Success]: ✔ should encode a Uint8Array into a Base58 string RTrace: +113

[Describe]: Base64

 [Success]: ✔ should decode a Base64 string into a Uint8Array RTrace: +69
 [Success]: ✔ should encode a Uint8Array into a Base64 string RTrace: +28

[Describe]: StringBytes

 [Success]: ✔ should convert a string into a Uint8Array RTrace: +22
 [Success]: ✔ should convert a Uint8Array into a string RTrace: +37

[Describe]: Crypto

 [Success]: ✔ should convert a public key into an address RTrace: +169
 [Success]: ✔ Multihash class RTrace: +136

[Describe]: Arrays

 [Success]: ✔ should compare two Uint8Array RTrace: +61
 [Success]: ✔ should convert hex strings RTrace: +188

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/util.spec.ts
  [Groups]: 6 pass, 6 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 10 pass,  0 fail, 10 total
    [Time]: 120.994ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [Result]: ✔ PASS
   [Files]: 6 total
  [Groups]: 29 count, 29 pass
   [Tests]: 173 pass, 0 fail, 173 total
    [Time]: 46043.17ms
┌──────────────────────────────┬───────┬───────┬───────┬───────┬──────────────────────────────────────────┐
│ File                         │ Total │ Block │ Func  │ Expr  │ Uncovered                                │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/systemCalls.ts      │ 62.9% │ 64.4% │ 61.2% │ 60%   │ 14:7, 43:58, 43:3, 54:76, 54:3, 65:93... │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/base64.ts      │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/base58.ts      │ 95%   │ 92.3% │ 100%  │ 100%  │ 68:40                                    │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/stringBytes.ts │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/crypto.ts      │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/arrays.ts      │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/safeMath.ts    │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/mockVM.ts      │ 95%   │ 95.7% │ 94.1% │ N/A   │ 267:58, 267:3                            │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/token.ts       │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/space.ts       │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ total                        │ 88.7% │ 88.7% │ 84.5% │ 95.2% │                                          │
└──────────────────────────────┴───────┴───────┴───────┴───────┴──────────────────────────────────────────┘

✨  Done in 46.52s.
```
