### PR TITLE
Bump proto-as, mock-vm, and fix build

### DIFF
--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -201,7 +201,7 @@ describe('SystemCalls', () => {
       System.recoverPublicKey(Base64.decode('IHhJwlD7P-o6x7L38den1MnumUhnYmNhTZhIUQQhezvEMf7rx89NbIIioNCIQSk1PQYdQ9mOI4-rDYiwO2pLvM4='), System.hash(Crypto.multicodec.sha2_256, StringBytes.stringToBytes(message))!, -1);
     }).toThrow();
 
-    expect(MockVM.getExitCode()).toBe(error.error_code.invalid_dsa);
+    expect(MockVM.getExitCode()).toBe(error.error_code.unknown_dsa);
   });
 
   it('should verify a signature', () => {

--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -648,7 +648,7 @@ export namespace System {
    * ```
    */
   export function revert(message: string = "", code: i32 = 1): void {
-    exit(code >= error.error_code.reverted ? code : error.error_code.reverted, StringBytes.stringToBytes(message))
+    exit(code >= error.error_code.reversion ? code : error.error_code.reversion, StringBytes.stringToBytes(message))
   }
 
   /**

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -205,7 +205,6 @@ export namespace MockVM {
       authorityValueType.int32_value = auth.autorization_type;
 
       authoritiesListType.values.push(authorityValueType);
-
     }
 
     System.putObject(METADATA_SPACE, 'authority', authoritiesListType, value.list_type.encode);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assemblyscript": "^0.19.22",
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
-    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#gov-updates",
+    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#testnet-4",
     "koinos-proto-as": "https://github.com/koinos/koinos-proto-as#testnet-4",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assemblyscript": "^0.19.22",
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
-    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#testnet-4",
+    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#gov-updates",
     "koinos-proto-as": "https://github.com/koinos/koinos-proto-as#testnet-4",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,27 +1454,27 @@ koinos-as-gen@0.4.8:
   dependencies:
     google-protobuf "^3.19.4"
 
-"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#testnet-4":
+"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#gov-updates":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#ea864f05dd6e72605a31f52201883423c3bd8289"
+  resolved "https://github.com/koinos/koinos-mock-vm#9d16fc3a8150c42f173bfbf2346700afea42814c"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"
     chalk "4.1.2"
-    koinos-proto-js "https://github.com/koinos/koinos-proto-js#gov-updates"
+    koinos-proto-js "https://github.com/koinos/koinos-proto-js#testnet-4"
     multibase "^4.0.6"
     protobufjs "^6.11.2"
     somap "^0.5.14"
 
 "koinos-proto-as@https://github.com/koinos/koinos-proto-as#testnet-4":
   version "0.4.2"
-  resolved "https://github.com/koinos/koinos-proto-as#b7ab54d83a8c7eb5d0f4379c5f1b738c1b3136df"
+  resolved "https://github.com/koinos/koinos-proto-as#5685a2a8475a72801f9de10dde94a91e1ae34a9c"
   dependencies:
     as-proto "^0.2.2"
 
-"koinos-proto-js@https://github.com/koinos/koinos-proto-js#gov-updates":
+"koinos-proto-js@https://github.com/koinos/koinos-proto-js#testnet-4":
   version "0.0.4"
-  resolved "https://github.com/koinos/koinos-proto-js#b3afb7a90031e1e4cfca286654c6578eea6f5c4f"
+  resolved "https://github.com/koinos/koinos-proto-js#03023d63f2938a7721e2ba077a5b21e6ecf3de46"
 
 levn@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,9 +1454,9 @@ koinos-as-gen@0.4.8:
   dependencies:
     google-protobuf "^3.19.4"
 
-"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#gov-updates":
+"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#testnet-4":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#9d16fc3a8150c42f173bfbf2346700afea42814c"
+  resolved "https://github.com/koinos/koinos-mock-vm#4f5842db394f59ebe46a25afa5bb7b034d7ab997"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"


### PR DESCRIPTION
Resolves #26

## Brief description

Bumps mock-vm, proto-as, and fixes tests

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
yarn run v1.22.18
$ asp --verbose
       ___   _____                       __    
      /   | / ___/      ____  ___  _____/ /_   
     / /| | \__ \______/ __ \/ _ \/ ___/ __/   
    / ___ |___/ /_____/ /_/ /  __/ /__/ /_     
   /_/  |_/____/     / .___/\___/\___/\__/     
                    /_/                        

⚡AS-pect⚡ Test suite runner [6.2.4]

[Log] Loading asc compiler
Assemblyscript Folder:assemblyscript
[Log] Compiler loaded in 356.75ms.
[Log] Using configuration /Users/mdv/git/koinos-sdk-as/as-pect.config.js
[Log] Using VerboseReporter
[Log] Including files: /Users/mdv/git/koinos-sdk-as/__tests__/**/*.spec.ts
[Log] Running tests that match: (:?)
[Log] Running groups that match: (:?)
[Log] Effective command line args:
  [TestFile.ts] node_modules/@as-pect/assembly/assembly/index.ts --runtime incremental --debug --binaryFile output.wasm --explicitStart --use ASC_RTRACE=1 --exportTable --importMemory --transform /Users/mdv/git/koinos-sdk-as/node_modules/@as-covers/transform/lib/index.js,/Users/mdv/git/koinos-sdk-as/node_modules/@as-pect/core/lib/transform/index.js --lib node_modules/@as-covers/assembly/index.ts

[Describe]: MockVM

 [Success]: ✔ should get the chain id RTrace: +34
 [Success]: ✔ should set the contract arguments RTrace: +57
 [Success]: ✔ should set the contract id RTrace: +31
 [Success]: ✔ should set the head info RTrace: +40
 [Success]: ✔ should set the last irreversible block RTrace: +32
 [Success]: ✔ should set the caller RTrace: +42
 [Success]: ✔ should set the transaction RTrace: +43
 [Success]: ✔ should set the block RTrace: +39
 [Success]: ✔ should set the authorities RTrace: +108
 [Success]: ✔ should set the call contract results RTrace: +82
 [Success]: ✔ should reset the MockVM database RTrace: +79
 [Success]: ✔ should handle transactions RTrace: +215
[Log] log 1
[Log] log 2
[Log] log 3
 [Success]: ✔ should handle logs RTrace: +168
 [Success]: ✔ should handle error messages RTrace: +44

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/mockVM.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 14 pass,  0 fail, 14 total
    [Time]: 128.314ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: tryAdd

 [Success]: ✔ adds correctly RTrace: +30
 [Success]: ✔ adds correctly - u128 RTrace: +46
 [Success]: ✔ reverts on addition overflow RTrace: +30
 [Success]: ✔ reverts on addition overflow - u128 RTrace: +48
 [Success]: ✔ adds correctly if it does not overflow and the result is positive RTrace: +30
 [Success]: ✔ adds correctly if it does not overflow and the result is negative RTrace: +30
 [Success]: ✔ reverts on positive addition overflow RTrace: +30
 [Success]: ✔ reverts on negative addition overflow RTrace: +30

[Describe]: add

 [Success]: ✔ adds correctly RTrace: +16
 [Success]: ✔ adds correctly - u128 RTrace: +32
[Contract Exit] could not add 18446744073709551615 to 1
[Contract Exit] could not add 1 to 18446744073709551615
 [Success]: ✔ reverts on addition overflow RTrace: +102
[Contract Exit] could not add
[Contract Exit] could not add
 [Success]: ✔ reverts on addition overflow - u128 RTrace: +104
 [Success]: ✔ adds correctly if it does not overflow and the result is positive RTrace: +16
 [Success]: ✔ adds correctly if it does not overflow and the result is negative RTrace: +16
[Contract Exit] could not add 9223372036854775807 to 1
[Contract Exit] could not add 1 to 9223372036854775807
 [Success]: ✔ reverts on positive addition overflow RTrace: +102
[Contract Exit] could not add -9223372036854775808 to -1
[Contract Exit] could not add -1 to -9223372036854775808
 [Success]: ✔ reverts on negative addition overflow RTrace: +102
[Contract Exit] my message
[Contract Exit] my message1
[Contract Exit] my message2
 [Success]: ✔ reverts with a custom message RTrace: +148

[Describe]: trySub

 [Success]: ✔ subtracts correctly RTrace: +15
 [Success]: ✔ subtracts correctly - u128 RTrace: +24
 [Success]: ✔ reverts if subtraction result would be negative RTrace: +15
 [Success]: ✔ reverts if subtraction result would be negative - u128 RTrace: +24
 [Success]: ✔ subtracts correctly if it does not overflow and the result is positive RTrace: +15
 [Success]: ✔ subtracts correctly if it does not overflow and the result is negative RTrace: +15
 [Success]: ✔ reverts on positive subtraction overflow RTrace: +15
 [Success]: ✔ reverts on negative subtraction overflow RTrace: +15

[Describe]: sub

 [Success]: ✔ subtracts correctly RTrace: +8
 [Success]: ✔ subtracts correctly - u128 RTrace: +17
[Contract Exit] could not subtract 5678 from 1234
 [Success]: ✔ reverts if subtraction result would be negative RTrace: +51
[Contract Exit] could not subtract
 [Success]: ✔ reverts if subtraction result would be negative - u128 RTrace: +51
 [Success]: ✔ subtracts correctly if it does not overflow and the result is positive RTrace: +8
 [Success]: ✔ subtracts correctly if it does not overflow and the result is negative RTrace: +8
[Contract Exit] could not subtract -1 from 9223372036854775807
 [Success]: ✔ reverts on positive subtraction overflow RTrace: +51
[Contract Exit] could not subtract 1 from -9223372036854775808
 [Success]: ✔ reverts on negative subtraction overflow RTrace: +51
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts with a custom message RTrace: +99

[Describe]: tryMul

 [Success]: ✔ multiplies correctly RTrace: +30
 [Success]: ✔ multiplies correctly - u128 RTrace: +50
 [Success]: ✔ multiplies correctly - signed integers RTrace: +60
 [Success]: ✔ multiplies by zero correctly RTrace: +30
 [Success]: ✔ multiplies by zero correctly - u128 RTrace: +49
 [Success]: ✔ multiplies by zero correctly - signed integers RTrace: +30
 [Success]: ✔ reverts on multiplication overflow RTrace: +30
 [Success]: ✔ reverts on multiplication overflow - u128 RTrace: +832
 [Success]: ✔ reverts on multiplication overflow, positive operands RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i64 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i32 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i16 RTrace: +30
 [Success]: ✔ reverts when minimum integer is multiplied by -1 - i8 RTrace: +30

[Describe]: mul

 [Success]: ✔ multiplies correctly RTrace: +16
 [Success]: ✔ multiplies correctly - u128 RTrace: +36
 [Success]: ✔ multiplies by zero correctly RTrace: +16
 [Success]: ✔ multiplies by zero correctly - u128 RTrace: +35
[Contract Exit] could not multiply
[Contract Exit] could not multiply
 [Success]: ✔ reverts on multiplication overflow - u128 RTrace: +888
[Contract Exit] could not multiply 9223372036854775807 by 2
[Contract Exit] could not multiply 2 by 9223372036854775807
 [Success]: ✔ reverts on multiplication overflow RTrace: +102
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts on multiplication overflow with a custom message RTrace: +96

[Describe]: tryDiv

 [Success]: ✔ divides correctly RTrace: +15
 [Success]: ✔ divides correctly - u128 RTrace: +25
 [Success]: ✔ divides correctly - signed integers RTrace: +15
 [Success]: ✔ divides zero correctly RTrace: +15
 [Success]: ✔ divides zero correctly - u128 RTrace: +25
 [Success]: ✔ divides zero correctly - signed integers RTrace: +15
 [Success]: ✔ returns complete number result on non-even division RTrace: +15
 [Success]: ✔ returns complete number result on non-even division - u128 RTrace: +25
 [Success]: ✔ returns complete number result on non-even division - signed integers RTrace: +15
 [Success]: ✔ reverts on division by zero RTrace: +15
 [Success]: ✔ reverts on division by zero - u128 RTrace: +25
 [Success]: ✔ reverts on division by zero - signed integers RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i64 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i32 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i16 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i8 RTrace: +15

[Describe]: div

 [Success]: ✔ divides correctly RTrace: +8
 [Success]: ✔ divides correctly - u128 RTrace: +18
 [Success]: ✔ divides zero correctly RTrace: +8
 [Success]: ✔ divides zero correctly - u128 RTrace: +18
 [Success]: ✔ returns complete number result on non-even division RTrace: +8
 [Success]: ✔ returns complete number result on non-even division - u128 RTrace: +18
[Contract Exit] could not divide 5678 by 0
 [Success]: ✔ reverts on division by zero RTrace: +50
[Contract Exit] could not divide
 [Success]: ✔ reverts on division by zero - u128 RTrace: +52
[Contract Exit] my message
[Contract Exit] my message1
 [Success]: ✔ reverts on division by zero with a custom message RTrace: +100

[Describe]: trymod

[Describe]: modulos correctly

 [Success]: ✔ when the dividend is smaller than the divisor RTrace: +15
 [Success]: ✔ when the dividend is smaller than the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is smaller than the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is equal to the divisor RTrace: +15
 [Success]: ✔ when the dividend is equal to the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is equal to the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is larger than the divisor RTrace: +15
 [Success]: ✔ when the dividend is larger than the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is larger than the divisor - signed integers RTrace: +15
 [Success]: ✔ when the dividend is a multiple of the divisor RTrace: +15
 [Success]: ✔ when the dividend is a multiple of the divisor - u128 RTrace: +25
 [Success]: ✔ when the dividend is a multiple of the divisor - signed integers RTrace: +15

 [Success]: ✔ reverts with a 0 divisor RTrace: +15
 [Success]: ✔ reverts with a 0 divisor - u128 RTrace: +25
 [Success]: ✔ reverts with a 0 divisor - signed integers RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i64 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i32 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i16 RTrace: +15
 [Success]: ✔ reverts on overflow, negative second - i8 RTrace: +15

[Describe]: mod

[Describe]: modulos correctly

 [Success]: ✔ when the dividend is smaller than the divisor RTrace: +8
 [Success]: ✔ when the dividend is smaller than the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is equal to the divisor RTrace: +8
 [Success]: ✔ when the dividend is equal to the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is larger than the divisor RTrace: +8
 [Success]: ✔ when the dividend is larger than the divisor - u128 RTrace: +18
 [Success]: ✔ when the dividend is a multiple of the divisor RTrace: +8
 [Success]: ✔ when the dividend is a multiple of the divisor - u128 RTrace: +18

[Contract Exit] could not calulate 5678 modulo 0
 [Success]: ✔ reverts with a 0 divisor RTrace: +50
[Contract Exit] could not calulate modulo
 [Success]: ✔ reverts with a 0 divisor - u128 RTrace: +52
[Contract Exit] my message
 [Success]: ✔ reverts with a 0 divisor with a custom message RTrace: +48
[Contract Exit] my message
 [Success]: ✔ reverts with a 0 divisor with a custom message - u128 RTrace: +52

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/safeMath.spec.ts
  [Groups]: 14 pass, 14 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 110 pass,  0 fail, 110 total
    [Time]: 574.522ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: space

 [Success]: ✔ should put and get an object RTrace: +52
 [Success]: ✔ should check if space has an object or not RTrace: +45
 [Success]: ✔ should remove an object RTrace: +57
 [Success]: ✔ should get next and prev object RTrace: +141
 [Success]: ✔ should get many RTrace: +738

[Describe]: space with proto key

 [Success]: ✔ should put and get an object RTrace: +48
 [Success]: ✔ should check if space has an object or not RTrace: +45
 [Success]: ✔ should remove an object RTrace: +55
 [Success]: ✔ should get next and prev object RTrace: +141
 [Success]: ✔ should get many RTrace: +521

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/space.spec.ts
  [Groups]: 3 pass, 3 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 10 pass,  0 fail, 10 total
    [Time]: 178.608ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: SystemCalls

 [Success]: ✔ should get the chain id RTrace: +31
 [Success]: ✔ should get the head info RTrace: +40
 [Success]: ✔ should get the transaction RTrace: +43
 [Success]: ✔ should get the transaction field RTrace: +39
 [Success]: ✔ should get the block RTrace: +39
 [Success]: ✔ should get the block field RTrace: +47
 [Success]: ✔ should get the last irreversible block RTrace: +32
[Contract Exit] 
[Contract Exit] 
 [Success]: ✔ should require authorities RTrace: +130
[Log] Hello World!
 [Success]: ✔ should log RTrace: +47
[Event] Hello World! / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe' ] / SGVsbG8gV29ybGQh
[Log] 1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe
 [Success]: ✔ should emit an event RTrace: +154
[Contract Exit] unknown hash code
 [Success]: ✔ should hash RTrace: +381
[Contract Exit] unexpected dsa
 [Success]: ✔ should recover a public key RTrace: +246
 [Success]: ✔ should verify a signature RTrace: +80
 [Success]: ✔ should should call a contract RTrace: +80
 [Success]: ✔ should get the contract arguments RTrace: +57
 [Success]: ✔ should get the contract id RTrace: +31
 [Success]: ✔ should get the head info RTrace: +40
 [Success]: ✔ should get the caller RTrace: +42
[Contract Result] 
[Contract Exit] 
[Contract Exit] my message
 [Success]: ✔ should exit a contract RTrace: +164
 [Success]: ✔ should put and get bytes RTrace: +337
 [Success]: ✔ should put and get objects RTrace: +218

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/systemCalls.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 21 pass,  0 fail, 21 total
    [Time]: 288.464ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: token

 [Success]: ✔ should get the name of a token RTrace: +59
 [Success]: ✔ should get the symbol of a token RTrace: +56
 [Success]: ✔ should get the decimals of a token RTrace: +49
 [Success]: ✔ should get the total supply of a token RTrace: +49
 [Success]: ✔ should get the balance of an account RTrace: +49
 [Success]: ✔ should/not tranfer a token RTrace: +96
 [Success]: ✔ should/not mint a token RTrace: +96
 [Success]: ✔ should/not burn a token RTrace: +96

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/token.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 8 pass,  0 fail, 8 total
    [Time]: 83.342ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[Describe]: Base58

 [Success]: ✔ should decode a Base58 string into a Uint8Array RTrace: +209
 [Success]: ✔ should encode a Uint8Array into a Base58 string RTrace: +113

[Describe]: Base64

 [Success]: ✔ should decode a Base64 string into a Uint8Array RTrace: +69
 [Success]: ✔ should encode a Uint8Array into a Base64 string RTrace: +28

[Describe]: StringBytes

 [Success]: ✔ should convert a string into a Uint8Array RTrace: +22
 [Success]: ✔ should convert a Uint8Array into a string RTrace: +37

[Describe]: Crypto

 [Success]: ✔ should convert a public key into an address RTrace: +169
 [Success]: ✔ Multihash class RTrace: +136

[Describe]: Arrays

 [Success]: ✔ should compare two Uint8Array RTrace: +61
 [Success]: ✔ should convert hex strings RTrace: +188

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/util.spec.ts
  [Groups]: 6 pass, 6 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 10 pass,  0 fail, 10 total
    [Time]: 106.668ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [Result]: ✔ PASS
   [Files]: 6 total
  [Groups]: 29 count, 29 pass
   [Tests]: 173 pass, 0 fail, 173 total
    [Time]: 42851.324ms
┌──────────────────────────────┬───────┬───────┬───────┬───────┬──────────────────────────────────────────┐
│ File                         │ Total │ Block │ Func  │ Expr  │ Uncovered                                │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/systemCalls.ts      │ 62.9% │ 64.4% │ 61.2% │ 60%   │ 14:7, 43:58, 43:3, 54:76, 54:3, 65:93... │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/base64.ts      │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/base58.ts      │ 95%   │ 92.3% │ 100%  │ 100%  │ 68:40                                    │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/stringBytes.ts │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/crypto.ts      │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/arrays.ts      │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/safeMath.ts    │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/mockVM.ts      │ 95.6% │ 96.2% │ 94.7% │ N/A   │ 266:58, 266:3                            │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/token.ts       │ 100%  │ 100%  │ 100%  │ N/A   │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ assembly/util/space.ts       │ 100%  │ 100%  │ 100%  │ 100%  │                                          │
├──────────────────────────────┼───────┼───────┼───────┼───────┼──────────────────────────────────────────┤
│ total                        │ 88.8% │ 88.8% │ 84.7% │ 95.2% │                                          │
└──────────────────────────────┴───────┴───────┴───────┴───────┴──────────────────────────────────────────┘

✨  Done in 43.31s.
```
