### PR TITLE
System fail, revert

### DIFF
--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -288,28 +288,32 @@ describe('SystemCalls', () => {
 
     expect(MockVM.getExitCode()).toBe(0);
 
-    const message = "my message";
+    const messageA = "my message A";
 
     expect(() => {
-      System.exit(2, StringBytes.stringToBytes(message));
+      System.exit(-2, StringBytes.stringToBytes(messageA));
     }).toThrow();
 
-    expect(MockVM.getExitCode()).toBe(2);
-    expect(MockVM.getErrorMessage()).toBe(message);
+    expect(MockVM.getExitCode()).toBe(-2);
+    expect(MockVM.getErrorMessage()).toBe(messageA);
+
+    const messageB = "my message B";
 
     expect(() => {
-      System.revert(message);
-    })
-
-    expect(MockVM.getExitCode()).toBe(1);
-    expect(MockVM.getErrorMessage()).toBe(message);
-
-    expect(() => {
-      System.fail(message);
-    })
+      System.fail(messageB);
+    }).toThrow();
 
     expect(MockVM.getExitCode()).toBe(-1);
-    expect(MockVM.getErrorMessage()).toBe(message);
+    expect(MockVM.getErrorMessage()).toBe(messageB);
+
+    const messageC = "my message C";
+
+    expect(() => {
+      System.revert(messageC);
+    }).toThrow();
+
+    expect(MockVM.getExitCode()).toBe(1);
+    expect(MockVM.getErrorMessage()).toBe(messageC);
   });
 
   it('should put and get bytes', () => {

--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -291,10 +291,10 @@ describe('SystemCalls', () => {
     const message = "my message";
 
     expect(() => {
-      System.exit(1, StringBytes.stringToBytes(message));
+      System.exit(2, StringBytes.stringToBytes(message));
     }).toThrow();
 
-    expect(MockVM.getExitCode()).toBe(1);
+    expect(MockVM.getExitCode()).toBe(2);
     expect(MockVM.getErrorMessage()).toBe(message);
 
     expect(() => {
@@ -302,6 +302,13 @@ describe('SystemCalls', () => {
     })
 
     expect(MockVM.getExitCode()).toBe(1);
+    expect(MockVM.getErrorMessage()).toBe(message);
+
+    expect(() => {
+      System.fail(message);
+    })
+
+    expect(MockVM.getExitCode()).toBe(-1);
     expect(MockVM.getErrorMessage()).toBe(message);
   });
 

--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -635,11 +635,11 @@ export namespace System {
     let args = new system_calls.exit_arguments();
     args.code = code;
 
-    if ( value ) {
+    if (value) {
       if (code == error.error_code.success) {
-        args.res = new chain.result( value );
+        args.res = new chain.result(value);
       } else {
-        args.res = new chain.result( null, new chain.error_data(StringBytes.bytesToString(value)));
+        args.res = new chain.result(null, new chain.error_data(StringBytes.bytesToString(value)));
       }
     }
 
@@ -647,14 +647,34 @@ export namespace System {
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
+    env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
+  }
+
+  /**
+   * Fail the transaction in progress
+   * @param message Optional failure message
+   * @param code Optional error code, must be < 0, else code -1 is used (failure exit code)
+   * ```ts
+   * if (!System.checkAuthority(authority.authorization_type.transaction_application, Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe)))
+   *   System.fail("contract is not authorized");
+   * ```
+   */
+  export function fail(message: string = "", code: i32 = -1): void {
+    let args = new system_calls.exit_arguments();
+    args.res = new chain.result(null, new chain.error_data(message));
+    args.code = code < error.error_code.success ? code : error.error_code.failure;
+
+    const encodedArgs = Protobuf.encode(args, system_calls.exit_arguments.encode);
+    const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
+    const returnBytes = new Uint32Array(1);
+
+    env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
   }
 
   /**
    * Revert the transaction in progress
    * @param message Optional reversion message
-   * @param code Optional error code, must be >= 1, else code 1 is used (reverted exit code)
+   * @param code Optional error code, must be > 0, else code 1 is used (reverted exit code)
    * ```ts
    * if (!System.checkAuthority(authority.authorization_type.transaction_application, Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe)))
    *   System.revert("contract is not authorized");
@@ -662,15 +682,14 @@ export namespace System {
    */
   export function revert(message: string = "", code: i32 = 1): void {
     let args = new system_calls.exit_arguments();
-    args.res = new chain.result( null, new chain.error_data(message) );
-    args.code = code >= error.error_code.success ? code : error.error_code.reversion;
+    args.res = new chain.result(null, new chain.error_data(message));
+    args.code = code > error.error_code.success ? code : error.error_code.reversion;
 
     const encodedArgs = Protobuf.encode(args, system_calls.exit_arguments.encode);
     const readBuffer = new Uint8Array(MAX_BUFFER_SIZE);
     const returnBytes = new Uint32Array(1);
 
-    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
-    checkErrorCode(retcode, readBuffer.slice(0, returnBytes[0]));
+    env.invokeSystemCall(system_call_ids.system_call_id.exit, readBuffer.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, returnBytes.dataStart as u32);
   }
 
   /**

--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -2,6 +2,7 @@ import { env } from "./env";
 import { Protobuf, Reader, Writer } from 'as-proto';
 import { system_calls, system_call_ids, chain, protocol, authority, value, error } from 'koinos-proto-as';
 import { StringBytes } from ".";
+import { Base58 } from "./util";
 
 export namespace System {
   export const DEFAULT_MAX_BUFFER_SIZE = 1024;
@@ -786,7 +787,7 @@ export namespace System {
     * ```
     */
   export function requireAuthority(type: authority.authorization_type, account: Uint8Array): void {
-    require(checkAuthority(type, account));
+    require(checkAuthority(type, account), "account '" + Base58.encode(account) + "' authorization failed", error.error_code.authorization_failure);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assemblyscript": "^0.19.22",
     "eslint": "^8.7.0",
     "koinos-abi-proto-gen": "^0.1.5",
-    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#error-data",
+    "koinos-mock-vm": "https://github.com/koinos/koinos-mock-vm#testnet-4",
     "koinos-proto-as": "0.4.6",
     "source-map-support": "^0.5.21",
     "typedoc": "^0.22.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,9 +1454,9 @@ koinos-as-gen@0.4.8:
   dependencies:
     google-protobuf "^3.19.4"
 
-"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#error-data":
+"koinos-mock-vm@https://github.com/koinos/koinos-mock-vm#testnet-4":
   version "1.1.1"
-  resolved "https://github.com/koinos/koinos-mock-vm#ef766ed999e2873d4d1caddcbc2ba4cc6cd38c4b"
+  resolved "https://github.com/koinos/koinos-mock-vm#328c823ae1da77ec496da0f120228bacb6061d55"
   dependencies:
     "@noble/hashes" "^1.0.0"
     "@noble/secp256k1" "^1.5.5"


### PR DESCRIPTION
Resolves #35

## Brief description
Adds a `System.fail` API call.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
[Contract Exit]
[Contract Exit] my message A
[Contract Exit] my message B
[Contract Exit] my message C
 [Success]: ✔ should exit a contract RTrace: +250

[Contract Exit] account '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe' authorization failed
[Contract Exit] account '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe' authorization failed
 [Success]: ✔ should require authorities RTrace: +420
```
