### PR TITLE
add `getOperation` syscall and fix tests

### DIFF
--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -78,7 +78,7 @@ describe('MockVM', () => {
     expect(Arrays.equal(getTransaction.id, setTransaction.id)).toBe(true);
   });
 
-  xit('should set the operation', () => {
+  it('should set the operation', () => {
     let setOperation = new protocol.operation();
     setOperation.set_system_contract = new protocol.set_system_contract_operation(mockAccount, true);
 
@@ -209,7 +209,7 @@ describe('MockVM', () => {
   });
 
   it("should set verify vrf proof results", () => {
-    MockVM.setVerifyVRFPRoofResults([false, true]);
+    MockVM.setVerifyVRFProofResults([false, true]);
 
     expect(System.verifyVRFProof(new Uint8Array(0), new Uint8Array(0), new Uint8Array(0), new Uint8Array(0))).toBe(false);
     expect(System.verifyVRFProof(new Uint8Array(0), new Uint8Array(0), new Uint8Array(0), new Uint8Array(0))).toBe(true);

--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -11,7 +11,7 @@ describe('MockVM', () => {
   it('should get the chain id', () => {
     const chainId = mockAccount;
 
-    MockVM.setChainId(chainId)
+    MockVM.setChainId(chainId);
 
     expect(Arrays.equal(System.getChainId(), chainId)).toBe(true);
   });
@@ -24,7 +24,7 @@ describe('MockVM', () => {
     const getContractArgs = System.getArguments();
 
     expect(Arrays.equal(getContractArgs.args, mockAccount)).toBe(true);
-    expect(getContractArgs.entry_point).toBe(setEntryPoint)
+    expect(getContractArgs.entry_point).toBe(setEntryPoint);
   });
 
   it('should set the contract id', () => {
@@ -193,7 +193,7 @@ describe('MockVM', () => {
     const message = "my message";
     System.putBytes(MockVM.METADATA_SPACE, 'error_message', StringBytes.stringToBytes(message));
 
-    expect(MockVM.getErrorMessage()).toBe(message)
+    expect(MockVM.getErrorMessage()).toBe(message);
   });
 
   it("should set verify vrf proof results", () => {

--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -78,6 +78,18 @@ describe('MockVM', () => {
     expect(Arrays.equal(getTransaction.id, setTransaction.id)).toBe(true);
   });
 
+  xit('should set the operation', () => {
+    let setOperation = new protocol.operation();
+    setOperation.set_system_contract = new protocol.set_system_contract_operation(mockAccount, true);
+
+    MockVM.setOperation(setOperation);
+
+    const getOperation = System.getOperation();
+
+    expect(Arrays.equal(getOperation.set_system_contract!.contract_id, setOperation.set_system_contract!.contract_id)).toBe(true);
+    expect(getOperation.set_system_contract!.system_contract).toBe(true);
+  });
+
   it('should set the block', () => {
     let setBlock = new protocol.block(mockId);
 

--- a/__tests__/space.spec.ts
+++ b/__tests__/space.spec.ts
@@ -1,4 +1,4 @@
-import { Base58, StringBytes, Space, Arrays, Protobuf, System } from "../assembly";
+import { Base58, StringBytes, Storage, Arrays, Protobuf } from "../assembly";
 import { test_object } from './test';
 
 const mockContractId = Base58.decode('1DQzuCcTKacbs9GGScFTU1Hc8BsyARTPqe');
@@ -7,7 +7,7 @@ const mockKey = StringBytes.stringToBytes("0x12345");
 describe('space', () => {
   it('should put and get an object', () => {
     const obj = new test_object(42);
-    const Objects = new Space.Space<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
+    const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
     const key = 'key1';
 
     Objects.put(key, obj);
@@ -19,7 +19,7 @@ describe('space', () => {
 
   it('should check if space has an object or not', () => {
     const key = 'key1';
-    const Objects = new Space.Space<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
+    const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
 
     expect(Objects.has(key)).toBe(true);
     expect(Objects.has('key2')).toBe(false);
@@ -27,7 +27,7 @@ describe('space', () => {
 
   it('should remove an object', () => {
     const key = 'key1';
-    const Objects = new Space.Space<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
+    const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
 
     expect(Objects.has(key)).toBe(true);
     Objects.remove(key);
@@ -36,7 +36,7 @@ describe('space', () => {
 
   it('should get next and prev object', () => {
     const obj = new test_object(42);
-    const Objects = new Space.Space<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
+    const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
 
     Objects.put('key1', obj);
     Objects.put('key3', obj);
@@ -54,7 +54,7 @@ describe('space', () => {
   });
 
   it('should get many', () => {
-    const Objects = new Space.Space<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
+    const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
 
     Objects.put('key1', new test_object(1));
     Objects.put('key3', new test_object(3));
@@ -74,13 +74,13 @@ describe('space', () => {
     expect(Arrays.equal(objs[0].key, StringBytes.stringToBytes('key2'))).toBe(true);
     expect(Arrays.equal(objs[1].key, StringBytes.stringToBytes('key3'))).toBe(true);
 
-    objs = Objects.getMany('key4', 2, Space.Direction.Descending);
+    objs = Objects.getMany('key4', 2, Storage.Direction.Descending);
 
     expect(objs.length).toBe(2);
     expect(Arrays.equal(objs[0].key, StringBytes.stringToBytes('key3'))).toBe(true);
     expect(Arrays.equal(objs[1].key, StringBytes.stringToBytes('key2'))).toBe(true);
 
-    let keys = Objects.getManyKeys('key4', 2, Space.Direction.Descending);
+    let keys = Objects.getManyKeys('key4', 2, Storage.Direction.Descending);
     expect(keys.length).toBe(2);
     expect(keys[0]).toBe('key3');
     expect(keys[1]).toBe('key2');
@@ -90,7 +90,7 @@ describe('space', () => {
     expect(keys[0]).toBe('key2');
     expect(keys[1]).toBe('key3');
 
-    let values = Objects.getManyValues('key4', 2, Space.Direction.Descending);
+    let values = Objects.getManyValues('key4', 2, Storage.Direction.Descending);
     expect(values.length).toBe(2);
     expect(values[0].value).toBe(3);
     expect(values[1].value).toBe(2);
@@ -100,20 +100,20 @@ describe('space', () => {
     expect(values[0].value).toBe(2);
     expect(values[1].value).toBe(3);
 
-    const Objects2 = new Space.Space<Uint8Array, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
+    const Objects2 = new Storage.Map<Uint8Array, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
 
-    objs = Objects2.getMany(StringBytes.stringToBytes('key4'), 2, Space.Direction.Descending);
+    objs = Objects2.getMany(StringBytes.stringToBytes('key4'), 2, Storage.Direction.Descending);
 
     expect(objs.length).toBe(2);
     expect(Arrays.equal(objs[0].key, StringBytes.stringToBytes('key3'))).toBe(true);
     expect(Arrays.equal(objs[1].key, StringBytes.stringToBytes('key2'))).toBe(true);
 
-    const keys2 = Objects2.getManyKeys(StringBytes.stringToBytes('key4'), 2, Space.Direction.Descending);
+    const keys2 = Objects2.getManyKeys(StringBytes.stringToBytes('key4'), 2, Storage.Direction.Descending);
     expect(keys2.length).toBe(2);
     expect(Arrays.equal(keys2[0], StringBytes.stringToBytes('key3'))).toBe(true);
     expect(Arrays.equal(keys2[1], StringBytes.stringToBytes('key2'))).toBe(true);
 
-    const values2 = Objects2.getManyValues(StringBytes.stringToBytes('key4'), 2, Space.Direction.Descending);
+    const values2 = Objects2.getManyValues(StringBytes.stringToBytes('key4'), 2, Storage.Direction.Descending);
     expect(values2.length).toBe(2);
     expect(values2[0].value).toBe(3);
     expect(values2[1].value).toBe(2);
@@ -124,7 +124,7 @@ describe('space with proto key', () => {
   it('should put and get an object', () => {
     const key = new test_object(1);
     const obj = new test_object(42);
-    const Objects = new Space.SpaceProtoKey<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
+    const Objects = new Storage.ProtoMap<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
 
     Objects.put(key, obj);
 
@@ -135,7 +135,7 @@ describe('space with proto key', () => {
 
   it('should check if space has an object or not', () => {
     const key = new test_object(1);
-    const Objects = new Space.SpaceProtoKey<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
+    const Objects = new Storage.ProtoMap<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
 
     expect(Objects.has(key)).toBe(true);
     expect(Objects.has(new test_object(2))).toBe(false);
@@ -143,7 +143,7 @@ describe('space with proto key', () => {
 
   it('should remove an object', () => {
     const key = new test_object(1);
-    const Objects = new Space.SpaceProtoKey<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
+    const Objects = new Storage.ProtoMap<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
 
     expect(Objects.has(key)).toBe(true);
     Objects.remove(key);
@@ -152,7 +152,7 @@ describe('space with proto key', () => {
 
   it('should get next and prev object', () => {
     const obj = new test_object(42);
-    const Objects = new Space.SpaceProtoKey<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
+    const Objects = new Storage.ProtoMap<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
 
     Objects.put(new test_object(1), obj);
     Objects.put(new test_object(3), obj);
@@ -170,7 +170,7 @@ describe('space with proto key', () => {
   });
 
   it('should get many', () => {
-    const Objects = new Space.SpaceProtoKey<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
+    const Objects = new Storage.ProtoMap<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
 
     Objects.put(new test_object(1), new test_object(10));
     Objects.put(new test_object(3), new test_object(30));
@@ -190,7 +190,7 @@ describe('space with proto key', () => {
     expect(Arrays.equal(objs[0].key, Protobuf.encode(new test_object(2), test_object.encode))).toBe(true);
     expect(Arrays.equal(objs[1].key, Protobuf.encode(new test_object(3), test_object.encode))).toBe(true);
 
-    objs = Objects.getManyObj(new test_object(4), 2, Space.Direction.Descending);
+    objs = Objects.getManyObj(new test_object(4), 2, Storage.Direction.Descending);
 
     expect(objs.length).toBe(2);
     expect(Arrays.equal(objs[0].key, Protobuf.encode(new test_object(3), test_object.encode))).toBe(true);
@@ -202,7 +202,7 @@ describe('space with proto key', () => {
     expect(values[0].value).toBe(20);
     expect(values[1].value).toBe(30);
 
-    values = Objects.getManyObjValues(new test_object(4), 2, Space.Direction.Descending);
+    values = Objects.getManyObjValues(new test_object(4), 2, Storage.Direction.Descending);
 
     expect(values.length).toBe(2);
     expect(values[0].value).toBe(30);
@@ -214,7 +214,7 @@ describe('space with proto key', () => {
     expect(key[0].value).toBe(2);
     expect(key[1].value).toBe(3);
     
-    key = Objects.getManyObjKeys(new test_object(4), 2, Space.Direction.Descending);
+    key = Objects.getManyObjKeys(new test_object(4), 2, Storage.Direction.Descending);
 
     expect(key.length).toBe(2);
     expect(key[0].value).toBe(3);

--- a/__tests__/storage.spec.ts
+++ b/__tests__/storage.spec.ts
@@ -4,8 +4,8 @@ import { test_object } from './test';
 const mockContractId = Base58.decode('1DQzuCcTKacbs9GGScFTU1Hc8BsyARTPqe');
 const mockKey = StringBytes.stringToBytes("0x12345");
 
-describe('space', () => {
-  it('should put and get an object', () => {
+describe('storage', () => {
+  it('should put and get an object in a Map', () => {
     const obj = new test_object(42);
     const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
     const key = 'key1';
@@ -17,7 +17,15 @@ describe('space', () => {
     expect(storedObj!.value).toBe(obj.value);
   });
 
-  it('should check if space has an object or not', () => {
+  it('should get an object in a Map with default value', () => {
+    const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode, () => new test_object(42));
+    const key = 'idonotexist';
+
+    let storedObj = Objects.get(key);
+    expect(storedObj!.value).toBe(42);
+  });
+
+  it('should check if storage has an object or not', () => {
     const key = 'key1';
     const Objects = new Storage.Map<String, test_object>(mockContractId, 1, test_object.decode, test_object.encode);
 
@@ -120,7 +128,7 @@ describe('space', () => {
   });
 });
 
-describe('space with proto key', () => {
+describe('storage with proto key', () => {
   it('should put and get an object', () => {
     const key = new test_object(1);
     const obj = new test_object(42);
@@ -133,7 +141,7 @@ describe('space with proto key', () => {
     expect(storedObj!.value).toBe(obj.value);
   });
 
-  it('should check if space has an object or not', () => {
+  it('should check if storage has an object or not', () => {
     const key = new test_object(1);
     const Objects = new Storage.ProtoMap<test_object, test_object>(mockContractId, 2,test_object.decode, test_object.encode, test_object.decode, test_object.encode);
 
@@ -219,5 +227,29 @@ describe('space with proto key', () => {
     expect(key.length).toBe(2);
     expect(key[0].value).toBe(3);
     expect(key[1].value).toBe(2);
+  });
+
+  it('should put, get and remove an object in a Obj', () => {
+    const obj = new test_object(42);
+    const objStorage = new Storage.Obj<test_object>(mockContractId, 100, test_object.decode, test_object.encode);
+
+    objStorage.put(obj);
+
+    let storedObj = objStorage.get();
+    expect(storedObj).not.toBeNull();
+    expect(storedObj!.value).toBe(obj.value);
+
+    objStorage.remove();
+
+    storedObj = objStorage.get();
+    expect(storedObj).toBeNull();
+  });
+
+  it('should get  an object in a Obj with default value', () => {
+    const objStorage = new Storage.Obj<test_object>(mockContractId, 1000, test_object.decode, test_object.encode, () => new test_object(42));
+
+    let storedObj = objStorage.get();
+    expect(storedObj).not.toBeNull();
+    expect(storedObj!.value).toBe(42);
   });
 });

--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -55,7 +55,7 @@ describe('SystemCalls', () => {
     expect(Arrays.equal(getTransaction!.bytes_value, setTransaction.id)).toBe(true);
   });
 
-  xit('should get the operation', () => {
+  it('should get the operation', () => {
     let setOperation = new protocol.operation();
     setOperation.set_system_contract = new protocol.set_system_contract_operation(mockAccount, true);
 

--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -55,6 +55,18 @@ describe('SystemCalls', () => {
     expect(Arrays.equal(getTransaction!.bytes_value, setTransaction.id)).toBe(true);
   });
 
+  xit('should get the operation', () => {
+    let setOperation = new protocol.operation();
+    setOperation.set_system_contract = new protocol.set_system_contract_operation(mockAccount, true);
+
+    MockVM.setOperation(setOperation);
+
+    const getOperation = System.getOperation();
+
+    expect(Arrays.equal(getOperation.set_system_contract!.contract_id, setOperation.set_system_contract!.contract_id)).toBe(true);
+    expect(getOperation.set_system_contract!.system_contract).toBe(true);
+  });
+
   it('should get the block', () => {
     let setBlock = new protocol.block(mockId);
 

--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -17,7 +17,7 @@ describe('SystemCalls', () => {
   it('should get the chain id', () => {
     const chainId = mockAccount;
 
-    MockVM.setChainId(chainId)
+    MockVM.setChainId(chainId);
 
     expect(Arrays.equal(System.getChainId(), chainId)).toBe(true);
   });
@@ -249,7 +249,7 @@ describe('SystemCalls', () => {
     const getContractArgs = System.getArguments();
 
     expect(Arrays.equal(getContractArgs.args, mockAccount)).toBe(true);
-    expect(getContractArgs.entry_point).toBe(setEntryPoint)
+    expect(getContractArgs.entry_point).toBe(setEntryPoint);
   });
 
   it('should get the contract id', () => {

--- a/assembly/systemCalls.ts
+++ b/assembly/systemCalls.ts
@@ -172,6 +172,25 @@ export namespace System {
   }
 
   /**
+    * Get the current operation
+    * @returns protocol.operation
+    * @example
+    * ```ts
+    *  const op = System.getOperation();
+    * ```
+    */
+  export function getOperation(): protocol.operation {
+    const args = new system_calls.get_operation_arguments();
+    const encodedArgs = Protobuf.encode(args, system_calls.get_operation_arguments.encode);
+
+    const retcode = env.invokeSystemCall(system_call_ids.system_call_id.get_operation, SYSTEM_CALL_BUFFER.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, RETURN_BYTES.dataStart as u32);
+    checkErrorCode(retcode, SYSTEM_CALL_BUFFER.slice(0, RETURN_BYTES[0]));
+    const result = Protobuf.decode<system_calls.get_operation_result>(SYSTEM_CALL_BUFFER, system_calls.get_operation_result.decode, RETURN_BYTES[0]);
+
+    return result.value!;
+  }
+
+  /**
     * Get the current block
     * @returns protocol.block
     * @example
@@ -479,7 +498,7 @@ export namespace System {
    * @param type type of signature
    */
   export function verifyVRFProof(publicKey: Uint8Array, proof: Uint8Array, hash: Uint8Array, message: Uint8Array, type: chain.dsa = chain.dsa.ecdsa_secp256k1): bool {
-    const args = new system_calls.verify_vrf_proof_arguments(type, publicKey, proof, hash, message );
+    const args = new system_calls.verify_vrf_proof_arguments(type, publicKey, proof, hash, message);
     const encodedArgs = Protobuf.encode(args, system_calls.verify_vrf_proof_arguments.encode);
 
     const retcode = env.invokeSystemCall(system_call_ids.system_call_id.verify_vrf_proof, SYSTEM_CALL_BUFFER.dataStart as u32, MAX_BUFFER_SIZE, encodedArgs.dataStart as u32, encodedArgs.byteLength, RETURN_BYTES.dataStart as u32);
@@ -552,7 +571,7 @@ export namespace System {
       result.object = Protobuf.decode<system_calls.call_result>(SYSTEM_CALL_BUFFER, system_calls.call_result.decode, RETURN_BYTES[0]).value;
     }
 
-    return {code: retcode, res: result};
+    return { code: retcode, res: result };
   }
 
   export class getArgumentsReturn {
@@ -585,10 +604,10 @@ export namespace System {
 
     let ret = new getArgumentsReturn();
 
-    if ( result.value ) {
+    if (result.value) {
       ret.entry_point = result.value!.entry_point;
 
-      if ( result.value!.arguments ) {
+      if (result.value!.arguments) {
         ret.args = result.value!.arguments!;
       }
     }
@@ -725,7 +744,7 @@ export namespace System {
     * System.checkAuthority(authority.authorization_type.transaction_application, Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe));
     * ```
     */
-  export function checkAuthority(type: authority.authorization_type, account: Uint8Array, data: Uint8Array | null = null ): bool {
+  export function checkAuthority(type: authority.authorization_type, account: Uint8Array, data: Uint8Array | null = null): bool {
     const args = new system_calls.check_authority_arguments(type, account, data);
     const encodedArgs = Protobuf.encode(args, system_calls.check_authority_arguments.encode);
 
@@ -735,16 +754,16 @@ export namespace System {
     return result.value;
   }
 
-   /**
-    * Require authority for an account
-    * @param type type of authority required
-    * @param account account to check
-    * @throws revert the transaction if the account is not authorized
-    * @example
-    * ```ts
-    * System.requireAuthority(authority.authorization_type.transaction_application, Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe));
-    * ```
-    */
+  /**
+   * Require authority for an account
+   * @param type type of authority required
+   * @param account account to check
+   * @throws revert the transaction if the account is not authorized
+   * @example
+   * ```ts
+   * System.requireAuthority(authority.authorization_type.transaction_application, Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe));
+   * ```
+   */
   export function requireAuthority(type: authority.authorization_type, account: Uint8Array): void {
     require(checkAuthority(type, account), "account '" + Base58.encode(account) + "' authorization failed", error.error_code.authorization_failure);
   }

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -156,23 +156,17 @@ export namespace MockVM {
   }
 
   /**
-    * Set transaction that will be used when calling System.getTransaction() and System.getTransactionField(...)
-    * @param { protocol.transaction } transaction transaction to set
+    * Set operation that will be used when calling System.getOperation()
+    * @param { protocol.operation } operation operation to set
     * @example
     * ```ts
-    * let transaction = new protocol.transaction();
-    * transaction.id = StringBytes.stringToBytes("0x12345");
+    * let setOperation = new protocol.operation();
+    * setOperation.set_system_contract = new protocol.set_system_contract_operation(Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe'), true);
     *
-    * MockVM.setTransaction(transaction);
+    * MockVM.setOperation(setOperation);
     *
-    * transaction = System.getTransaction();
-    *
-    * System.log("transaction.id: " + (StringBytes.bytesToString((transaction.id)!)!));
-    *
-    * let txField = System.getTransactionField('id');
-    * if (txField) {
-    *   System.log("transaction.id: " + (StringBytes.bytesToString((txField.bytes_value) as Uint8Array) as string));
-    * }
+    * const getOperation = System.getOperation();
+    * ...
     * ```
     */
   export function setOperation(operation: protocol.operation): void {
@@ -252,14 +246,14 @@ export namespace MockVM {
    }
    * ```
    */
-  export function setVerifyVRFPRoofResults(verifyVRFProofResults: bool[]): void {
+  export function setVerifyVRFProofResults(verifyVRFProofResults: bool[]): void {
     const verifyVRFProofResultListType = new value.list_type();
 
     for (let index = 0; index < verifyVRFProofResults.length; index++) {
-      const callVerufyVRFProofValueType = new value.value_type();
-      callVerufyVRFProofValueType.bool_value = verifyVRFProofResults[index];
+      const callVerifyVRFProofValueType = new value.value_type();
+      callVerifyVRFProofValueType.bool_value = verifyVRFProofResults[index];
 
-      verifyVRFProofResultListType.values.push(callVerufyVRFProofValueType);
+      verifyVRFProofResultListType.values.push(callVerifyVRFProofValueType);
     }
 
     System.putObject(METADATA_SPACE, 'verify_vrf', verifyVRFProofResultListType, value.list_type.encode);

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -156,6 +156,30 @@ export namespace MockVM {
   }
 
   /**
+    * Set transaction that will be used when calling System.getTransaction() and System.getTransactionField(...)
+    * @param { protocol.transaction } transaction transaction to set
+    * @example
+    * ```ts
+    * let transaction = new protocol.transaction();
+    * transaction.id = StringBytes.stringToBytes("0x12345");
+    *
+    * MockVM.setTransaction(transaction);
+    *
+    * transaction = System.getTransaction();
+    *
+    * System.log("transaction.id: " + (StringBytes.bytesToString((transaction.id)!)!));
+    *
+    * let txField = System.getTransactionField('id');
+    * if (txField) {
+    *   System.log("transaction.id: " + (StringBytes.bytesToString((txField.bytes_value) as Uint8Array) as string));
+    * }
+    * ```
+    */
+  export function setOperation(operation: protocol.operation): void {
+    System.putObject(METADATA_SPACE, 'operation', operation, protocol.operation.encode);
+  }
+
+  /**
     * Set block that will be used when calling System.getBlock() and System.getBlockField(...)
     * @param { protocol.block } block block to set
     * @example
@@ -210,36 +234,36 @@ export namespace MockVM {
     System.putObject(METADATA_SPACE, 'authority', authoritiesListType, value.list_type.encode);
   }
 
-   /**
-    * Set results that will be used when calling System.verifyVRFProof(...)
-    * @param { Uint8Array[] } verifyVRFProofResults The results are FIFO, so the first System.verifyVRFPRoof(...) used in your code will use the first result you set in callContractResults, the second System.callContract(...) will get the second result, etc...
-    * @example
-    * ```ts
-    MockVM.setVerifyVRFProofResults([false, true]);
+  /**
+   * Set results that will be used when calling System.verifyVRFProof(...)
+   * @param { Uint8Array[] } verifyVRFProofResults The results are FIFO, so the first System.verifyVRFPRoof(...) used in your code will use the first result you set in callContractResults, the second System.callContract(...) will get the second result, etc...
+   * @example
+   * ```ts
+   MockVM.setVerifyVRFProofResults([false, true]);
 
-    let callRes = System.verifyVRFProof(pubKey, proof, hash, messgae);
-    if (callRes) {
-      // Will execute
+   let callRes = System.verifyVRFProof(pubKey, proof, hash, messgae);
+   if (callRes) {
+     // Will execute
+   }
+
+   let callRes = System.verifyVRFProof(pubKey, proof, hash, messgae);
+   if (callRes) {
+     // Will not execute
+   }
+   * ```
+   */
+  export function setVerifyVRFPRoofResults(verifyVRFProofResults: bool[]): void {
+    const verifyVRFProofResultListType = new value.list_type();
+
+    for (let index = 0; index < verifyVRFProofResults.length; index++) {
+      const callVerufyVRFProofValueType = new value.value_type();
+      callVerufyVRFProofValueType.bool_value = verifyVRFProofResults[index];
+
+      verifyVRFProofResultListType.values.push(callVerufyVRFProofValueType);
     }
 
-    let callRes = System.verifyVRFProof(pubKey, proof, hash, messgae);
-    if (callRes) {
-      // Will not execute
-    }
-    * ```
-    */
-    export function setVerifyVRFPRoofResults(verifyVRFProofResults: bool[]): void {
-      const verifyVRFProofResultListType = new value.list_type();
-
-      for (let index = 0; index < verifyVRFProofResults.length; index++) {
-        const callVerufyVRFProofValueType = new value.value_type();
-        callVerufyVRFProofValueType.bool_value = verifyVRFProofResults[index];
-
-        verifyVRFProofResultListType.values.push(callVerufyVRFProofValueType);
-      }
-
-      System.putObject(METADATA_SPACE, 'verify_vrf', verifyVRFProofResultListType, value.list_type.encode);
-    }
+    System.putObject(METADATA_SPACE, 'verify_vrf', verifyVRFProofResultListType, value.list_type.encode);
+  }
 
   /**
     * Set call contract results that will be used when calling System.callContract(...)

--- a/assembly/util/storage.ts
+++ b/assembly/util/storage.ts
@@ -13,7 +13,7 @@ export namespace Storage {
 
   export class Map<TKey, TValue> {
     private space: chain.object_space;
-    private defaultValue: () => TValue | null;
+    private defaultValue: (() => TValue | null) | null;
     private valueDecoder: (reader: Reader, length: i32) => TValue;
     private valueEncoder: (message: TValue, writer: Writer) => void;
 
@@ -21,9 +21,9 @@ export namespace Storage {
     * Initialize a Space object with TKey the type of the keys and TValue the type of the values
     * @param contractId the id of the contract
     * @param spaceId the id of the space
-    * @param defaultValue arrow function that returns the default value
     * @param valueDecoder the protobuf decoder for the values
     * @param valueEncoder the protobuf encoder for the values
+    * @param defaultValue arrow function that returns the default value
     * @param system is system space
     * @example
     * ```ts
@@ -32,18 +32,18 @@ export namespace Storage {
     * const balances = new Storage.Map(
     *   this.contractId,
     *   BALANCES_SPACE_ID,
-    *   () => new token.uint64(0),
     *   token.uint64.decode,
-    *   token.uint64.encode
+    *   token.uint64.encode,
+    *   () => new token.uint64(0)
     * );
     * ```
     */
     constructor(
       contractId: Uint8Array,
       spaceId: u32,
-      defaultValue: () => TValue | null,
       valueDecoder: (reader: Reader, length: i32) => TValue,
       valueEncoder: (message: TValue, writer: Writer) => void,
+      defaultValue: (() => TValue | null) | null = null,
       system: bool = false) {
       this.space = new chain.object_space(system, contractId, spaceId);
       this.defaultValue = defaultValue;
@@ -301,13 +301,13 @@ export namespace Storage {
     constructor(
       contractId: Uint8Array,
       spaceId: u32,
-      defaultValue: () => TValue | null,
       keyDecoder: (reader: Reader, length: i32) => TKey,
       keyEncoder: (message: TKey, writer: Writer) => void,
       valueDecoder: (reader: Reader, length: i32) => TValue,
       valueEncoder: (message: TValue, writer: Writer) => void,
+      defaultValue: (() => TValue | null) | null = null,
       system: bool = false) {
-      super(contractId, spaceId, defaultValue, valueDecoder, valueEncoder, system);
+      super(contractId, spaceId, valueDecoder, valueEncoder, defaultValue, system);
       this.keyDecoder = keyDecoder;
       this.keyEncoder = keyEncoder;
     }
@@ -501,7 +501,7 @@ export namespace Storage {
 
   export class Obj<TValue> {
     private space: chain.object_space;
-    private defaultValue: () => TValue | null;
+    private defaultValue: (() => TValue | null) | null;
     private valueDecoder: (reader: Reader, length: i32) => TValue;
     private valueEncoder: (message: TValue, writer: Writer) => void;
 
@@ -509,9 +509,9 @@ export namespace Storage {
     * Initialize a Space object with TKey the type of the keys and TValue the type of the values
     * @param contractId the id of the contract
     * @param spaceId the id of the space
-    * @param defaultValue arrow function that returns the default value
     * @param valueDecoder the protobuf decoder for the values
     * @param valueEncoder the protobuf encoder for the values
+    * @param defaultValue arrow function that returns the default value
     * @param system is system space
     * @example
     * ```ts
@@ -520,18 +520,18 @@ export namespace Storage {
     * const supply = new Storage.Obj(
     *   contractId,
     *   SUPPLY_ID,
-    *   () => new token.uint64(0),
     *   token.uint64.decode,
-    *   token.uint64.encode
+    *   token.uint64.encode,
+    *   () => new token.uint64(0)
     * );
     * ```
     */
     constructor(
       contractId: Uint8Array,
       spaceId: u32,
-      defaultValue: () => TValue | null,
       valueDecoder: (reader: Reader, length: i32) => TValue,
       valueEncoder: (message: TValue, writer: Writer) => void,
+      defaultValue: (() => TValue | null) | null = null,
       system: bool = false) {
       this.space = new chain.object_space(system, contractId, spaceId);
       this.defaultValue = defaultValue;

--- a/assembly/util/storage.ts
+++ b/assembly/util/storage.ts
@@ -3,7 +3,7 @@ import { chain } from '@koinos/proto-as';
 import { Protobuf, Reader, Writer } from 'as-proto';
 import { StringBytes } from './stringBytes';
 
-const defaultKey = new Uint8Array(0);
+const DEFAULT_KEY = new Uint8Array(0);
 
 export namespace Storage {
   export enum Direction {
@@ -549,7 +549,7 @@ export namespace Storage {
     * ```
     */
     get(): TValue | null {
-      const value = System.getObject<Uint8Array, TValue>(this.space, defaultKey, this.valueDecoder);
+      const value = System.getObject<Uint8Array, TValue>(this.space, DEFAULT_KEY, this.valueDecoder);
       if (!value && this.defaultValue) return this.defaultValue();
       return value;
     }
@@ -563,7 +563,7 @@ export namespace Storage {
     * ```
     */
     put(object: TValue): void {
-      System.putObject(this.space, defaultKey, object, this.valueEncoder);
+      System.putObject(this.space, DEFAULT_KEY, object, this.valueEncoder);
     }
 
     /**
@@ -574,7 +574,7 @@ export namespace Storage {
     * ```
     */
     remove(): void {
-      System.removeObject(this.space, defaultKey);
+      System.removeObject(this.space, DEFAULT_KEY);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@koinos/abi-proto-gen": "^0.4.0",
     "@koinos/as-gen": "^0.4.0",
     "@koinos/as-proto-gen": "^0.4.3",
-    "@koinos/mock-vm": "^0.4.2",
+    "@koinos/mock-vm": "^0.4.3",
     "@koinos/proto-as": "^0.4.7",
     "@koinos/sdk-as-cli": "^0.4.1",
     "@roamin/protoc": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@koinos/mock-vm": "^0.4.2",
     "@koinos/proto-as": "^0.4.7",
     "@koinos/sdk-as-cli": "^0.4.1",
-    "@roaminroe/protoc": "^2.4.0",
+    "@roamin/protoc": "^2.4.0",
     "as-bignum": "^0.2.18",
     "as-proto": "npm:@koinos/as-proto",
     "assemblyscript": "^0.19.22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koinos/sdk-as",
-  "version": "0.5.0",
+  "version": "0.4.5",
   "main": "assembly/index.ts",
   "license": "MIT",
   "author": "Koinos Group <contact@koinos.group>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koinos/sdk-as",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "main": "assembly/index.ts",
   "license": "MIT",
   "author": "Koinos Group <contact@koinos.group>",

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,14 +88,14 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@eslint/eslintrc@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
-  integrity sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==
+"@eslint/eslintrc@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
+  integrity sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.3.2"
+    espree "^9.4.0"
     globals "^13.15.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
@@ -108,19 +108,19 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@humanwhocodes/config-array@^0.10.4":
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
-  integrity sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==
+"@humanwhocodes/config-array@^0.10.5":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"
+  integrity sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
     minimatch "^3.0.4"
 
-"@humanwhocodes/gitignore-to-minimatch@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz#316b0a63b91c10e53f242efb4ace5c3b34e8728d"
-  integrity sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
@@ -159,10 +159,10 @@
     ts-poet "^4.9.0"
     typescript "^4.6.4"
 
-"@koinos/mock-vm@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@koinos/mock-vm/-/mock-vm-0.4.2.tgz#c2fc8af6680c532bc83f1e3bfa4318d8250c7b00"
-  integrity sha512-qAxorppWvdt5spqTPO4NfGBpskWOkqaoy7r9xH8CvP2KaQ31jFM2eBmtscoSnAi+1/GTIwX035O/Wse/0qF9Vw==
+"@koinos/mock-vm@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@koinos/mock-vm/-/mock-vm-0.4.3.tgz#58976fc9c39a3f66c90d8f384712e327622b2674"
+  integrity sha512-9fg8VhRW2M55L0ug41dROEit2xOlZfZ/3kqJcwrGEJNSk896u6eHtROuHfS8eyD6q5HltYADPd6ECnmUNDzNYQ==
   dependencies:
     "@koinos/proto-js" "^0.4.0"
     "@noble/hashes" "^1.0.0"
@@ -173,16 +173,16 @@
     somap "^0.5.14"
 
 "@koinos/proto-as@^0.4.7":
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-0.4.7.tgz#1f4af9ac9f3ea4d484a8f8afd1f9d18c8243ead6"
-  integrity sha512-NJ0g02ctcQCZDQ+sd9bMqD3qc90KEHRHIpWUg91C3JpF0+JSWQzN41fSFxxZXfeirCj56px1n0GDfl6a6iWPLQ==
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-0.4.9.tgz#cebb9180193e27d852c20183caf5cf61743152ee"
+  integrity sha512-AXcq34yJcO1OnzCQkUbkACqF6oO1jvSlb1i8EBm3VSNyyxPym7aYQZljLBWSwc1A6LPo8U3hsUWFlgRuUXywfg==
   dependencies:
     as-proto "npm:@koinos/as-proto"
 
 "@koinos/proto-js@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@koinos/proto-js/-/proto-js-0.4.0.tgz#f55c225ff0caf446ba950bf4d8253cb28eb5bd53"
-  integrity sha512-6Xciwa1YrALwat7iRkYiQX/H8zvk/Qamo7iBtwAIZeyZTEEfxSaRrSB2f4pLzk9Ian6O4CmuRxHkr8Cws6FQNw==
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@koinos/proto-js/-/proto-js-0.4.6.tgz#d5cf71f8f9e4f415a23e6c8e28cac355d2dcc41d"
+  integrity sha512-cozSpILwmgB+NbT7580G/+AbSZBDtf1Ki9q9GUCXOTs5S4gIERyJfPhpE4Xrm8CieE88kJbELSeWyX0rxAEOtA==
 
 "@koinos/sdk-as-cli@^0.4.1":
   version "0.4.1"
@@ -198,14 +198,14 @@
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
 
 "@noble/hashes@^1.0.0":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
-  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.3.tgz#360afc77610e0a61f3417e497dcf36862e4f8111"
+  integrity sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==
 
 "@noble/secp256k1@^1.5.5":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
-  integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.0.tgz#d15357f7c227e751d90aa06b05a0e5cf993ba8c1"
+  integrity sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -228,10 +228,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@npmcli/arborist@^5.0.0", "@npmcli/arborist@^5.0.4":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@npmcli/arborist/-/arborist-5.6.0.tgz#ace635279d0d548df164ac83464237fd5f0175ad"
-  integrity sha512-gM2AxWCaXTZRZnKOHT6uIUHTkvRf+UPU2iC/3nC1Bj21zemnoKyJh2NvcG69UCcfs+r1jpx6hZ0dL9s2yPssJQ==
+"@npmcli/arborist@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/arborist/-/arborist-5.6.2.tgz#552b554f34777e5dcc8e68ad86cdaeebc0788790"
+  integrity sha512-Lyj2g+foWKzrwW2bT/RGO982VR9vb5tlvfD88n4PwWJRrDttQbJoIdcQzN9b+NIBhI1/8iEhC5b8far9U0fQxA==
   dependencies:
     "@isaacs/string-locale-compare" "^1.1.0"
     "@npmcli/installed-package-contents" "^1.0.7"
@@ -241,10 +241,10 @@
     "@npmcli/name-from-folder" "^1.0.1"
     "@npmcli/node-gyp" "^2.0.0"
     "@npmcli/package-json" "^2.0.0"
-    "@npmcli/query" "^1.1.1"
+    "@npmcli/query" "^1.2.0"
     "@npmcli/run-script" "^4.1.3"
-    bin-links "^3.0.0"
-    cacache "^16.0.6"
+    bin-links "^3.0.3"
+    cacache "^16.1.3"
     common-ancestor-path "^1.0.1"
     json-parse-even-better-errors "^2.3.1"
     json-stringify-nice "^1.1.4"
@@ -254,7 +254,7 @@
     nopt "^6.0.0"
     npm-install-checks "^5.0.0"
     npm-package-arg "^9.0.0"
-    npm-pick-manifest "^7.0.0"
+    npm-pick-manifest "^7.0.2"
     npm-registry-fetch "^13.0.0"
     npmlog "^6.0.2"
     pacote "^13.6.1"
@@ -379,7 +379,7 @@
   dependencies:
     infer-owner "^1.0.4"
 
-"@npmcli/query@^1.1.1":
+"@npmcli/query@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@npmcli/query/-/query-1.2.0.tgz#46468d583cf013aa92102970700f9555314aabe4"
   integrity sha512-uWglsUM3PjBLgTSmZ3/vygeGdvWEIZ3wTUnzGFbprC/RtvQSaT+GAXu1DXmSFj2bD3oOZdcRm1xdzsV2z1YWdw==
@@ -452,10 +452,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@roaminroe/protoc@^2.4.0":
+"@roamin/protoc@^2.4.0":
   version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@roaminroe/protoc/-/protoc-2.4.0.tgz#9f50b727af5bdf7a06e20ae38a2f9c80ef24a2d0"
-  integrity sha512-M2H/EaGYyNd4Zcskyf8PrtpMi7q7ewT+A7fPu3kIB3pN0y/8mXIuGRvqp8pO7LsKSCkGA+coCGTYeFLx7dC2lg==
+  resolved "https://registry.yarnpkg.com/@roamin/protoc/-/protoc-2.4.0.tgz#7d2d84f23aaac365024b3a14705f5605826e859a"
+  integrity sha512-vMVLvZ42wyQ3sd+vHzNAMGE2OSsURZ/CeuW3rnc8ueeNWhS1dVf9Nk6tQNd4GIINAMkjsBrl1eqdsmiaxV1epA==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -473,9 +473,9 @@
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/node@>=13.7.0":
-  version "18.7.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.13.tgz#23e6c5168333480d454243378b69e861ab5c011a"
-  integrity sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==
+  version "18.8.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.8.3.tgz#ce750ab4017effa51aed6a7230651778d54e327c"
+  integrity sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==
 
 "@types/node@^17.0.13", "@types/node@^17.0.34":
   version "17.0.45"
@@ -483,86 +483,86 @@
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
 "@typescript-eslint/eslint-plugin@^5.10.0":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.35.1.tgz#0d822bfea7469904dfc1bb8f13cabd362b967c93"
-  integrity sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz#778b2d9e7f293502c7feeea6c74dca8eb3e67511"
+  integrity sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.35.1"
-    "@typescript-eslint/type-utils" "5.35.1"
-    "@typescript-eslint/utils" "5.35.1"
+    "@typescript-eslint/scope-manager" "5.39.0"
+    "@typescript-eslint/type-utils" "5.39.0"
+    "@typescript-eslint/utils" "5.39.0"
     debug "^4.3.4"
-    functional-red-black-tree "^1.0.1"
     ignore "^5.2.0"
     regexpp "^3.2.0"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.10.0":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.35.1.tgz#bf2ee2ebeaa0a0567213748243fb4eec2857f04f"
-  integrity sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.39.0.tgz#93fa0bc980a3a501e081824f6097f7ca30aaa22b"
+  integrity sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.35.1"
-    "@typescript-eslint/types" "5.35.1"
-    "@typescript-eslint/typescript-estree" "5.35.1"
+    "@typescript-eslint/scope-manager" "5.39.0"
+    "@typescript-eslint/types" "5.39.0"
+    "@typescript-eslint/typescript-estree" "5.39.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.35.1":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.35.1.tgz#ccb69d54b7fd0f2d0226a11a75a8f311f525ff9e"
-  integrity sha512-kCYRSAzIW9ByEIzmzGHE50NGAvAP3wFTaZevgWva7GpquDyFPFcmvVkFJGWJJktg/hLwmys/FZwqM9EKr2u24Q==
+"@typescript-eslint/scope-manager@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz#873e1465afa3d6c78d8ed2da68aed266a08008d0"
+  integrity sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==
   dependencies:
-    "@typescript-eslint/types" "5.35.1"
-    "@typescript-eslint/visitor-keys" "5.35.1"
+    "@typescript-eslint/types" "5.39.0"
+    "@typescript-eslint/visitor-keys" "5.39.0"
 
-"@typescript-eslint/type-utils@5.35.1":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.35.1.tgz#d50903b56758c5c8fc3be52b3be40569f27f9c4a"
-  integrity sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==
+"@typescript-eslint/type-utils@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz#0a8c00f95dce4335832ad2dc6bc431c14e32a0a6"
+  integrity sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==
   dependencies:
-    "@typescript-eslint/utils" "5.35.1"
+    "@typescript-eslint/typescript-estree" "5.39.0"
+    "@typescript-eslint/utils" "5.39.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.35.1":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.35.1.tgz#af355fe52a0cc88301e889bc4ada72f279b63d61"
-  integrity sha512-FDaujtsH07VHzG0gQ6NDkVVhi1+rhq0qEvzHdJAQjysN+LHDCKDKCBRlZFFE0ec0jKxiv0hN63SNfExy0KrbQQ==
+"@typescript-eslint/types@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.39.0.tgz#f4e9f207ebb4579fd854b25c0bf64433bb5ed78d"
+  integrity sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==
 
-"@typescript-eslint/typescript-estree@5.35.1":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.35.1.tgz#db878a39a0dbdc9bb133f11cdad451770bfba211"
-  integrity sha512-JUqE1+VRTGyoXlDWWjm6MdfpBYVq+hixytrv1oyjYIBEOZhBCwtpp5ZSvBt4wIA1MKWlnaC2UXl2XmYGC3BoQA==
+"@typescript-eslint/typescript-estree@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz#c0316aa04a1a1f4f7f9498e3c13ef1d3dc4cf88b"
+  integrity sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==
   dependencies:
-    "@typescript-eslint/types" "5.35.1"
-    "@typescript-eslint/visitor-keys" "5.35.1"
+    "@typescript-eslint/types" "5.39.0"
+    "@typescript-eslint/visitor-keys" "5.39.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.35.1":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.35.1.tgz#ae1399afbfd6aa7d0ed1b7d941e9758d950250eb"
-  integrity sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==
+"@typescript-eslint/utils@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.39.0.tgz#b7063cca1dcf08d1d21b0d91db491161ad0be110"
+  integrity sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.35.1"
-    "@typescript-eslint/types" "5.35.1"
-    "@typescript-eslint/typescript-estree" "5.35.1"
+    "@typescript-eslint/scope-manager" "5.39.0"
+    "@typescript-eslint/types" "5.39.0"
+    "@typescript-eslint/typescript-estree" "5.39.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.35.1":
-  version "5.35.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.35.1.tgz#285e9e34aed7c876f16ff646a3984010035898e6"
-  integrity sha512-cEB1DvBVo1bxbW/S5axbGPE6b7FIMAbo3w+AGq6zNDA7+NYJOIkKj/sInfTv4edxd4PxJSgdN4t6/pbvgA+n5g==
+"@typescript-eslint/visitor-keys@5.39.0":
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz#8f41f7d241b47257b081ddba5d3ce80deaae61e2"
+  integrity sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==
   dependencies:
-    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/types" "5.39.0"
     eslint-visitor-keys "^3.3.0"
 
-abbrev@1, abbrev@^1.0.0, abbrev@~1.1.1:
+abbrev@^1.0.0, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -695,7 +695,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bin-links@^3.0.0:
+bin-links@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-3.0.3.tgz#3842711ef3db2cd9f16a5f404a996a12db355a6e"
   integrity sha512-zKdnMPWEdh4F5INR07/eBrodC7QrF5JKvqskjz/ZZRXg5YSAZIbn8zGhbhUrElzHBZ2fvEQdOU59RHcTG3GiwA==
@@ -751,7 +751,7 @@ builtins@^5.0.0:
   dependencies:
     semver "^7.0.0"
 
-cacache@^16.0.0, cacache@^16.0.6, cacache@^16.1.0, cacache@^16.1.1:
+cacache@^16.0.0, cacache@^16.1.0, cacache@^16.1.3:
   version "16.1.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-16.1.3.tgz#a02b9f34ecfaf9a78c9f4bc16fceb94d5d67a38e"
   integrity sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==
@@ -814,9 +814,9 @@ cli-columns@^4.0.0:
     strip-ansi "^6.0.1"
 
 cli-table3@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
-  integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
   dependencies:
     string-width "^4.2.0"
   optionalDependencies:
@@ -865,9 +865,9 @@ commander@^2.19.0:
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^9.0.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
-  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 common-ancestor-path@^1.0.1:
   version "1.0.1"
@@ -945,7 +945,7 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^5.0.0:
+diff@^5.0.0, diff@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
   integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
@@ -1030,13 +1030,13 @@ eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.7.0:
-  version "8.22.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.22.0.tgz#78fcb044196dfa7eef30a9d65944f6f980402c48"
-  integrity sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==
+  version "8.25.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.25.0.tgz#00eb962f50962165d0c4ee3327708315eaa8058b"
+  integrity sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==
   dependencies:
-    "@eslint/eslintrc" "^1.3.0"
-    "@humanwhocodes/config-array" "^0.10.4"
-    "@humanwhocodes/gitignore-to-minimatch" "^1.0.2"
+    "@eslint/eslintrc" "^1.3.3"
+    "@humanwhocodes/config-array" "^0.10.5"
+    "@humanwhocodes/module-importer" "^1.0.1"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -1046,13 +1046,12 @@ eslint@^8.7.0:
     eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
     eslint-visitor-keys "^3.3.0"
-    espree "^9.3.3"
+    espree "^9.4.0"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
     find-up "^5.0.0"
-    functional-red-black-tree "^1.0.1"
     glob-parent "^6.0.1"
     globals "^13.15.0"
     globby "^11.1.0"
@@ -1061,6 +1060,7 @@ eslint@^8.7.0:
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
+    js-sdsl "^4.1.4"
     js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
@@ -1072,12 +1072,11 @@ eslint@^8.7.0:
     strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
 
-espree@^9.3.2, espree@^9.3.3:
-  version "9.3.3"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.3.tgz#2dd37c4162bb05f433ad3c1a52ddf8a49dc08e9d"
-  integrity sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==
+espree@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.0.tgz#cd4bc3d6e9336c433265fc0aa016fc1aaf182f8a"
+  integrity sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==
   dependencies:
     acorn "^8.8.0"
     acorn-jsx "^5.3.2"
@@ -1118,9 +1117,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.2.9:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1202,11 +1201,6 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-functional-red-black-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
-
 gauge@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.4.tgz#52ff0652f2bbf607a989793d53b751bef2328dce"
@@ -1278,9 +1272,9 @@ globby@^11.1.0:
     slash "^3.0.0"
 
 google-protobuf@^3.19.2, google-protobuf@^3.19.4:
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.0.tgz#8dfa3fca16218618d373d414d3c1139e28034d6e"
-  integrity sha512-byR7MBTK4tZ5PZEb+u5ZTzpt4SfrTxv5682MjPlHN16XeqgZE2/8HOIWeiXe8JKnT9OVbtBGhbq8mtvkK8cd5g==
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.1.tgz#bb73c6e1471afdadc0a312da27ef0a68c875414f"
+  integrity sha512-iiQnqsR7nzdYfJjo2yOpJJ2bsAaOvV/85HjDx/sxcOJcNMgyj3iK00HsbZbhKS+EixWdu9fPn7quaBvb4IQHtw==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.10, graceful-fs@^4.2.6:
   version "4.2.10"
@@ -1309,7 +1303,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hosted-git-info@^5.0.0:
+hosted-git-info@^5.0.0, hosted-git-info@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.1.0.tgz#9786123f92ef3627f24abc3f15c20d98ec4a6594"
   integrity sha512-Ek+QmMEqZF8XrbFdwoDjSbm7rT23pCgEMOJmz6GPk/s4yH//RQfNPArhIxbguNxROq/+5lNBwCDHMhA903Kx1Q==
@@ -1400,7 +1394,7 @@ inherits@2, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^3.0.0:
+ini@^3.0.0, ini@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ini/-/ini-3.0.1.tgz#c76ec81007875bc44d544ff7a11a55d12294102d"
   integrity sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==
@@ -1486,6 +1480,11 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+js-sdsl@^4.1.4:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.5.tgz#1ff1645e6b4d1b028cd3f862db88c9d887f26e2a"
+  integrity sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -1519,9 +1518,9 @@ json-stringify-nice@^1.1.4:
   integrity sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==
 
 jsonc-parser@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
-  integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
+  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
 jsonparse@^1.3.1:
   version "1.3.1"
@@ -1546,36 +1545,36 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libnpmaccess@^6.0.2:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-6.0.3.tgz#473cc3e4aadb2bc713419d92e45d23b070d8cded"
-  integrity sha512-4tkfUZprwvih2VUZYMozL7EMKgQ5q9VW2NtRyxWtQWlkLTAWHRklcAvBN49CVqEkhUw7vTX2fNgB5LzgUucgYg==
+libnpmaccess@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-6.0.4.tgz#2dd158bd8a071817e2207d3b201d37cf1ad6ae6b"
+  integrity sha512-qZ3wcfIyUoW0+qSFkMBovcTrSGJ3ZeyvpR7d5N9pEYv/kXs8sHP2wiqEIXBKLFrZlmM0kR0RJD7mtfLngtlLag==
   dependencies:
     aproba "^2.0.0"
     minipass "^3.1.1"
     npm-package-arg "^9.0.1"
     npm-registry-fetch "^13.0.0"
 
-libnpmdiff@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/libnpmdiff/-/libnpmdiff-4.0.4.tgz#487ccb609dacd7f558f089feef3153933e157d02"
-  integrity sha512-bUz12309DdkeFL/K0sKhW1mbg8DARMbNI0vQKrJp1J8lxhxqkAjzSQ3eQCacFjSwCz4xaf630ogwuOkSt61ZEQ==
+libnpmdiff@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/libnpmdiff/-/libnpmdiff-4.0.5.tgz#ffaf93fa9440ea759444b8830fdb5c661b09a7c0"
+  integrity sha512-9fICQIzmH892UwHHPmb+Seup50UIBWcMIK2FdxvlXm9b4kc1nSH0b/BuY1mORJQtB6ydPMnn+BLzOTmd/SKJmw==
   dependencies:
     "@npmcli/disparity-colors" "^2.0.0"
     "@npmcli/installed-package-contents" "^1.0.7"
     binary-extensions "^2.2.0"
-    diff "^5.0.0"
+    diff "^5.1.0"
     minimatch "^5.0.1"
     npm-package-arg "^9.0.1"
     pacote "^13.6.1"
     tar "^6.1.0"
 
-libnpmexec@^4.0.2:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/libnpmexec/-/libnpmexec-4.0.11.tgz#3307fd7b683630268237936a921f5faadd5bfaef"
-  integrity sha512-uhkAWVT0pA1kVgqgTjIMVebOPl3PpIvVcRQ1IBV47ppVxmQr+JCjDahrV0K/0JUsKSVFozyGEEmg1Kz0HwRwzw==
+libnpmexec@^4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/libnpmexec/-/libnpmexec-4.0.13.tgz#6688bd6c02cac31a32d2e56680c3884948cbf453"
+  integrity sha512-MGi6eD6zqZ1V8VCJenWRc2+rWaFiW/Vkr5Aa/cQAd3duWNvXen9sm101M6ww5ER5PmsT+qX2aZOA3A9ZPfJQXg==
   dependencies:
-    "@npmcli/arborist" "^5.0.0"
+    "@npmcli/arborist" "^5.6.2"
     "@npmcli/ci-detect" "^2.0.0"
     "@npmcli/fs" "^2.1.1"
     "@npmcli/run-script" "^4.2.0"
@@ -1590,42 +1589,42 @@ libnpmexec@^4.0.2:
     semver "^7.3.7"
     walk-up-path "^1.0.0"
 
-libnpmfund@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/libnpmfund/-/libnpmfund-3.0.2.tgz#7da0827950f0db2cce0acb0dc7652d1834a8b239"
-  integrity sha512-wmFMP/93Wjy+jDg5LaSldDgAhSgCyA64JUUmp806Kae7y3YP9Qv5m1vUhPxT4yebxgB2v/I6G1/RUcNb1y0kVg==
+libnpmfund@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/libnpmfund/-/libnpmfund-3.0.4.tgz#be1fd46bcfa9432660f98d935135d7ee3e620239"
+  integrity sha512-azKUVFkL27AsvzEzLKMHX/L8j/GE2TL6eZ6KIdc9hsvleoNLT+Y6XO9w9v7JWwg03smZK9dbqwvnYZzO3vzrIA==
   dependencies:
-    "@npmcli/arborist" "^5.0.0"
+    "@npmcli/arborist" "^5.6.2"
 
-libnpmhook@^8.0.2:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/libnpmhook/-/libnpmhook-8.0.3.tgz#9628518a63455d21dafda312ee46175275707ff5"
-  integrity sha512-TEdNI1mC5zS+w/juCgxrwwQnpbq9lY76NDOS0N37pn6pWIUxB1Yq8mwy6MUEXR1TgH4HurSQyKT6I6Kp9Wjm4A==
-  dependencies:
-    aproba "^2.0.0"
-    npm-registry-fetch "^13.0.0"
-
-libnpmorg@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-4.0.3.tgz#a85cbdb3665ad4f7c7279d239a4581ec2eeef5a6"
-  integrity sha512-r4CpmCEF+e5PbFMBi64xSXmqn0uGgV4T7NWpGL4/A6KT/DTtIxALILQZq+l0ZdN1xm4RjOvqSDR22oT4il8rAQ==
+libnpmhook@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/libnpmhook/-/libnpmhook-8.0.4.tgz#6c58e5fe763ff5d600ae9c20457ea9a69d1f7d87"
+  integrity sha512-nuD6e+Nx0OprjEi0wOeqASMl6QIH235th/Du2/8upK3evByFhzIgdfOeP1OhstavW4xtsl0hk5Vw4fAWWuSUgA==
   dependencies:
     aproba "^2.0.0"
     npm-registry-fetch "^13.0.0"
 
-libnpmpack@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/libnpmpack/-/libnpmpack-4.1.2.tgz#9234a3b1ae433f922c19e97cd3a8a0b135b5f4cc"
-  integrity sha512-megSAPeZGv9jnDM4KovKbczjyuy/EcPxCIU/iaWsDU1IEAVtBJ0qHqNUm5yN2AgN501Tb3CL6KeFGYdG4E31rQ==
+libnpmorg@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-4.0.4.tgz#2a01d49372cf0df90d79a61e69bddaf2ed704311"
+  integrity sha512-1bTpD7iub1rDCsgiBguhJhiDufLQuc8DEti20euqsXz9O0ncXVpCYqf2SMmHR4GEdmAvAj2r7FMiyA9zGdaTpA==
+  dependencies:
+    aproba "^2.0.0"
+    npm-registry-fetch "^13.0.0"
+
+libnpmpack@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/libnpmpack/-/libnpmpack-4.1.3.tgz#025cfe39829acd8260662bf259e3a9331fc1e4b2"
+  integrity sha512-rYP4X++ME3ZiFO+2iN3YnXJ4LB4Gsd0z5cgszWJZxaEpDN4lRIXirSyynGNsN/hn4taqnlxD+3DPlFDShvRM8w==
   dependencies:
     "@npmcli/run-script" "^4.1.3"
     npm-package-arg "^9.0.1"
     pacote "^13.6.1"
 
-libnpmpublish@^6.0.2:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-6.0.4.tgz#adb41ec6b0c307d6f603746a4d929dcefb8f1a0b"
-  integrity sha512-lvAEYW8mB8QblL6Q/PI/wMzKNvIrF7Kpujf/4fGS/32a2i3jzUXi04TNyIBcK6dQJ34IgywfaKGh+Jq4HYPFmg==
+libnpmpublish@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-6.0.5.tgz#5a894f3de2e267d62f86be2a508e362599b5a4b1"
+  integrity sha512-LUR08JKSviZiqrYTDfywvtnsnxr+tOvBU0BF8H+9frt7HMvc6Qn6F8Ubm72g5hDTHbq8qupKfDvDAln2TVPvFg==
   dependencies:
     normalize-package-data "^4.0.0"
     npm-package-arg "^9.0.1"
@@ -1633,25 +1632,25 @@ libnpmpublish@^6.0.2:
     semver "^7.3.7"
     ssri "^9.0.0"
 
-libnpmsearch@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-5.0.3.tgz#ed502a4c2c70ea36723180455fae1357546b2184"
-  integrity sha512-Ofq76qKAPhxbiyzPf/5LPjJln26VTKwU9hIU0ACxQ6tNtBJ1CHmI7iITrdp7vNezhZc0FlkXwrIpqXjhBJZgLQ==
+libnpmsearch@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-5.0.4.tgz#b32aa2b23051c00cdcc0912274d0d416e6655d81"
+  integrity sha512-XHDmsvpN5+pufvGnfLRqpy218gcGGbbbXR6wPrDJyd1em6agKdYByzU5ccskDHH9iVm2UeLydpDsW1ksYuU0cg==
   dependencies:
     npm-registry-fetch "^13.0.0"
 
-libnpmteam@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-4.0.3.tgz#9335fbbd032b3770f5c9b7ffc6203f47d1ed144a"
-  integrity sha512-LsYYLz4TlTpcqkusInY5MhKjiHFaCx1GV0LmydXJ/QMh+3IWBJpUhes4ynTZuFoJKkDIFjxyMU09ul+RZixgdg==
+libnpmteam@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-4.0.4.tgz#ac26068808d93b1051d926457db14e4b3ff669ef"
+  integrity sha512-rzKSwi6MLzwwevbM/vl+BBQTErgn24tCfgPUdzBlszrw3j5necOu7WnTzgvZMDv6maGUwec6Ut1rxszOgH0l+Q==
   dependencies:
     aproba "^2.0.0"
     npm-registry-fetch "^13.0.0"
 
-libnpmversion@^3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/libnpmversion/-/libnpmversion-3.0.6.tgz#a4a476d38a44d38db9ac424a5e7334479e7fb8b9"
-  integrity sha512-+lI+AO7cZwDxyAeWCIR8+n9XEfgSDAqmNbv4zy+H6onGthsk/+E3aa+5zIeBpyG5g268zjpc0qrBch0Q3w0nBA==
+libnpmversion@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/libnpmversion/-/libnpmversion-3.0.7.tgz#e4c6c07ee28cf351ce1e2293a5ac9922b09ea94d"
+  integrity sha512-O0L4eNMUIMQ+effi1HsZPKp2N6wecwqGqB8PvkvmLPWN7EsdabdzAVG48nv0p/OjlbIai5KQg/L+qMMfCA4ZjA==
   dependencies:
     "@npmcli/git" "^3.0.0"
     "@npmcli/run-script" "^4.1.3"
@@ -1744,9 +1743,9 @@ make-fetch-happen@^10.0.3, make-fetch-happen@^10.0.6, make-fetch-happen@^10.2.0:
     ssri "^9.0.0"
 
 marked@^4.0.16:
-  version "4.0.19"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.19.tgz#d36198d1ac1255525153c351c68c75bc1d7aee46"
-  integrity sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.1.1.tgz#2f709a4462abf65a283f2453dc1c42ab177d302e"
+  integrity sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
@@ -1852,9 +1851,9 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 moo@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
-  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
 
 ms@2.1.2:
   version "2.1.2"
@@ -1899,27 +1898,20 @@ negotiator@^0.6.3:
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 node-gyp@^9.0.0, node-gyp@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.1.0.tgz#c8d8e590678ea1f7b8097511dedf41fc126648f8"
-  integrity sha512-HkmN0ZpQJU7FLbJauJTHkHlSVAXlNGDAzH/VYFZGDOnFyn/Na3GlNJfkudmufOdS6/jNFhy88ObzL7ERz9es1g==
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.2.0.tgz#b3b56144828a98018a4cfb3033095e0f5b874d72"
+  integrity sha512-/+/YxGfIJOh/fnMsr4Ep0v6oOIjnO1BgLd2dcDspBX1spTkQU7xSIox5RdRE/2/Uq3ZwK8Z5swRIbMUmPlslmg==
   dependencies:
     env-paths "^2.2.0"
     glob "^7.1.4"
     graceful-fs "^4.2.6"
     make-fetch-happen "^10.0.3"
-    nopt "^5.0.0"
+    nopt "^6.0.0"
     npmlog "^6.0.0"
     rimraf "^3.0.2"
     semver "^7.3.5"
     tar "^6.1.2"
     which "^2.0.2"
-
-nopt@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
-  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
-  dependencies:
-    abbrev "1"
 
 nopt@^6.0.0:
   version "6.0.0"
@@ -1977,9 +1969,9 @@ npm-normalize-package-bin@^2.0.0:
   integrity sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==
 
 npm-package-arg@^9.0.0, npm-package-arg@^9.0.1, npm-package-arg@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-9.1.0.tgz#a60e9f1e7c03e4e3e4e994ea87fff8b90b522987"
-  integrity sha512-4J0GL+u2Nh6OnhvUKXRr2ZMG4lR8qtLp+kv7UiV00Y+nGiSxtttCyIRHCt5L5BNkXQld/RceYItau3MDOoGiBw==
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-9.1.2.tgz#fc8acecb00235f42270dda446f36926ddd9ac2bc"
+  integrity sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==
   dependencies:
     hosted-git-info "^5.0.0"
     proc-log "^2.0.1"
@@ -1996,7 +1988,7 @@ npm-packlist@^5.1.0:
     npm-bundled "^2.0.0"
     npm-normalize-package-bin "^2.0.0"
 
-npm-pick-manifest@^7.0.0, npm-pick-manifest@^7.0.1:
+npm-pick-manifest@^7.0.0, npm-pick-manifest@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-7.0.2.tgz#1d372b4e7ea7c6712316c0e99388a73ed3496e84"
   integrity sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==
@@ -2033,12 +2025,12 @@ npm-user-validate@^1.0.1:
   integrity sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==
 
 npm@^8.3.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/npm/-/npm-8.18.0.tgz#bd6ca7f637720441f812370363e2ae67426fb42f"
-  integrity sha512-G07/yKvNUwhwxYhk8BxcuDPB/4s+y755i6CnH3lf9LQBHP5siUx66WbuNGWEnN3xaBER4+IR3OWApKX7eBO5Dw==
+  version "8.19.2"
+  resolved "https://registry.yarnpkg.com/npm/-/npm-8.19.2.tgz#db90e88584d065f51b069ab46b4f02f5cf4898b7"
+  integrity sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==
   dependencies:
     "@isaacs/string-locale-compare" "^1.1.0"
-    "@npmcli/arborist" "^5.0.4"
+    "@npmcli/arborist" "^5.6.2"
     "@npmcli/ci-detect" "^2.0.0"
     "@npmcli/config" "^4.2.1"
     "@npmcli/fs" "^2.1.0"
@@ -2047,7 +2039,7 @@ npm@^8.3.0:
     "@npmcli/run-script" "^4.2.1"
     abbrev "~1.1.1"
     archy "~1.0.0"
-    cacache "^16.1.1"
+    cacache "^16.1.3"
     chalk "^4.1.2"
     chownr "^2.0.0"
     cli-columns "^4.0.0"
@@ -2056,22 +2048,22 @@ npm@^8.3.0:
     fastest-levenshtein "^1.0.12"
     glob "^8.0.1"
     graceful-fs "^4.2.10"
-    hosted-git-info "^5.0.0"
-    ini "^3.0.0"
+    hosted-git-info "^5.1.0"
+    ini "^3.0.1"
     init-package-json "^3.0.2"
     is-cidr "^4.0.2"
     json-parse-even-better-errors "^2.3.1"
-    libnpmaccess "^6.0.2"
-    libnpmdiff "^4.0.2"
-    libnpmexec "^4.0.2"
-    libnpmfund "^3.0.1"
-    libnpmhook "^8.0.2"
-    libnpmorg "^4.0.2"
-    libnpmpack "^4.0.2"
-    libnpmpublish "^6.0.2"
-    libnpmsearch "^5.0.2"
-    libnpmteam "^4.0.2"
-    libnpmversion "^3.0.1"
+    libnpmaccess "^6.0.4"
+    libnpmdiff "^4.0.5"
+    libnpmexec "^4.0.13"
+    libnpmfund "^3.0.4"
+    libnpmhook "^8.0.4"
+    libnpmorg "^4.0.4"
+    libnpmpack "^4.1.3"
+    libnpmpublish "^6.0.5"
+    libnpmsearch "^5.0.4"
+    libnpmteam "^4.0.4"
+    libnpmversion "^3.0.7"
     make-fetch-happen "^10.2.0"
     minipass "^3.1.6"
     minipass-pipeline "^1.2.4"
@@ -2083,7 +2075,7 @@ npm@^8.3.0:
     npm-audit-report "^3.0.0"
     npm-install-checks "^5.0.0"
     npm-package-arg "^9.1.0"
-    npm-pick-manifest "^7.0.1"
+    npm-pick-manifest "^7.0.2"
     npm-profile "^6.2.0"
     npm-registry-fetch "^13.3.1"
     npm-user-validate "^1.0.1"
@@ -2095,7 +2087,7 @@ npm@^8.3.0:
     proc-log "^2.0.1"
     qrcode-terminal "^0.12.0"
     read "~1.0.7"
-    read-package-json "^5.0.1"
+    read-package-json "^5.0.2"
     read-package-json-fast "^2.0.3"
     readdir-scoped-modules "^1.1.0"
     rimraf "^3.0.2"
@@ -2345,7 +2337,7 @@ read-package-json-fast@^2.0.2, read-package-json-fast@^2.0.3:
     json-parse-even-better-errors "^2.3.0"
     npm-normalize-package-bin "^1.0.1"
 
-read-package-json@^5.0.0, read-package-json@^5.0.1:
+read-package-json@^5.0.0, read-package-json@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-5.0.2.tgz#b8779ccfd169f523b67208a89cc912e3f663f3fa"
   integrity sha512-BSzugrt4kQ/Z0krro8zhTwV1Kd79ue25IhNN/VtHFy1mG/6Tluyi+msc0UpwaoQzxSHa28mntAjIZY6kEgfR9Q==
@@ -2436,9 +2428,9 @@ safe-buffer@~5.2.0:
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^7.0.0, semver@^7.1.1, semver@^7.3.5, semver@^7.3.7:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -2502,9 +2494,9 @@ socks-proxy-agent@^7.0.0:
     socks "^2.6.2"
 
 socks@^2.6.2:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.0.tgz#f9225acdb841e874dca25f870e9130990f3913d0"
-  integrity sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
+  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
   dependencies:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
@@ -2691,9 +2683,9 @@ typedoc@^0.22.12:
     shiki "^0.10.1"
 
 typescript@^4.5.5, typescript@^4.6.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 unique-filename@^2.0.0:
   version "2.0.1"
@@ -2720,11 +2712,6 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 validate-npm-package-license@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Brief description
Content of this PR:

- adds `getOperation` system call (tests are written, but MockVM package needs to be updated in order to handle the new system call properly)
- makes the `defaultValue` optional in the Storage helper 
-  fixes the tests for the Storage helper (and add coverage tests)

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests