### PR TITLE
use `System.getBytes` in `has` function

### DIFF
--- a/assembly/util/storage.ts
+++ b/assembly/util/storage.ts
@@ -64,8 +64,7 @@ export namespace Storage {
     * ```
     */
     has(key: TKey): boolean {
-      const object = this.get(key);
-
+      const object = System.getBytes<TKey>(this.space, key);
       return object ? true : false;
     }
 
@@ -327,9 +326,7 @@ export namespace Storage {
     */
     has(key: TKey): boolean {
       const finalKey = Protobuf.encode(key, this.keyEncoder);
-      const object = this.map.get(finalKey);
-
-      return object ? true : false;
+      return this.map.has(finalKey);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koinos/sdk-as",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "assembly/index.ts",
   "license": "MIT",
   "author": "Koinos Group <contact@koinos.group>",


### PR DESCRIPTION
## Brief description
The `has` functions in `Storage.Map` and `Storage.ProtoMap` were relying on their internal `get` functions which would always return an object if a `defaultValue` was set in when instantiating those classes. Using `System.getBytes` directly prevents this issue from happening.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```ssh
[Describe]: storage

 [Success]: ✔ should put and get an object in a Map RTrace: +44
 [Success]: ✔ should get an object in a Map with default value RTrace: +18
 [Success]: ✔ should check if storage has an object or not RTrace: +36
 [Success]: ✔ should remove an object RTrace: +44
 [Success]: ✔ should get next and prev object RTrace: +121
 [Success]: ✔ should get many RTrace: +638

[Describe]: storage with proto key

 [Success]: ✔ should put and get an object RTrace: +41
 [Success]: ✔ should check if storage has an object or not RTrace: +37
 [Success]: ✔ should remove an object RTrace: +43
 [Success]: ✔ should get next and prev object RTrace: +122
 [Success]: ✔ should get many RTrace: +446
 [Success]: ✔ should put, get and remove an object in a Obj RTrace: +52
 [Success]: ✔ should get  an object in a Obj with default value RTrace: +23

    [File]: /home/rr/Documents/blockchain/koinos-sdk-as/__tests__/storage.spec.ts
  [Groups]: 3 pass, 3 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 13 pass,  0 fail, 13 total
    [Time]: 154.393ms
```
