### PR TITLE
feat: more functions for MockVM

### DIFF
--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -1,5 +1,5 @@
 import { Arrays, Base58, MockVM, StringBytes, System } from "../index";
-import { chain, protocol, authority, system_calls, Protobuf } from '@koinos/proto-as';
+import { chain, protocol, authority, system_calls } from '@koinos/proto-as';
 
 
 const mockAccount = Base58.decode('1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe');

--- a/__tests__/mockVM.spec.ts
+++ b/__tests__/mockVM.spec.ts
@@ -138,6 +138,7 @@ describe('MockVM', () => {
   });
 
   it('should get and clear the call contract arguments', () => {
+    MockVM.clearCallContractArguments();
     MockVM.setCallContractResults([
       new system_calls.exit_arguments(0, new chain.result())
     ]);

--- a/__tests__/systemCalls.spec.ts
+++ b/__tests__/systemCalls.spec.ts
@@ -106,6 +106,7 @@ describe('SystemCalls', () => {
     MockVM.setAuthorities([auth1, auth2, auth3]);
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.user_mode));
     MockVM.setContractArguments(mockAccount);
+    MockVM.setEntryPoint(0x4a2dbd90);
 
     // the System.requireAuthority that will fail will revert the database's VM, so we need to commit the transaction
     // this will backup the database

--- a/assembly/util/mockVM.ts
+++ b/assembly/util/mockVM.ts
@@ -324,11 +324,12 @@ export namespace MockVM {
    */
   export function getCallContractArguments(): system_calls.call_arguments[] {
     const callContractArgumentsListType = System.getObject<string, value.list_type>(METADATA_SPACE, "call_contract_arguments", value.list_type.decode);
+    if (!callContractArgumentsListType) return [];
     const callContractArguments = new Array<system_calls.call_arguments>(
-      callContractArgumentsListType!.values.length
+      callContractArgumentsListType.values.length
     );
-    for (let i = 0; i < callContractArgumentsListType!.values.length; i += 1) {
-      callContractArguments[i] = Protobuf.decode<system_calls.call_arguments>(callContractArgumentsListType!.values[i].bytes_value, system_calls.call_arguments.decode);
+    for (let i = 0; i < callContractArgumentsListType.values.length; i += 1) {
+      callContractArguments[i] = Protobuf.decode<system_calls.call_arguments>(callContractArgumentsListType.values[i].bytes_value, system_calls.call_arguments.decode);
     }
     return callContractArguments;
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@koinos/abi-proto-gen": "1.0.0",
     "@koinos/as-gen": "1.0.0",
     "@koinos/as-proto-gen": "1.0.0",
-    "@koinos/mock-vm": "1.2.0",
+    "@koinos/mock-vm": "1.3.0",
     "@koinos/proto-as": "2.2.0",
     "@koinos/sdk-as-cli": "^1.0.2",
     "@roamin/protoc": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,10 +220,10 @@
     ts-poet "^4.9.0"
     typescript "^4.6.4"
 
-"@koinos/mock-vm@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@koinos/mock-vm/-/mock-vm-1.2.0.tgz#1398ead9200fe5a30ec596773faa88a0dee20f78"
-  integrity sha512-hdCFD0xz0SZYOjL4nNZE5QSAJRGr5sRpPKVJBqvGoPclo7WTdY+c3EO+qvJYWTRwuj2/TpYeNl3Rjf8VqvJ0AQ==
+"@koinos/mock-vm@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@koinos/mock-vm/-/mock-vm-1.3.0.tgz#2df42153c8aba3a2cddcfe0e61214e81847dada6"
+  integrity sha512-ykriKnxOErekb1/Kcr91FMyBFt9OaGhC2d3w38lgkzfysUOK8ZKZ/FpGnA1/AzXpduFxU/dT4IrSJ4hSKGRg0g==
   dependencies:
     "@koinos/proto-js" "2.1.0"
     "@noble/hashes" "^1.0.0"


### PR DESCRIPTION
## Brief description
more functions for MockVM:
- `MockVM.getCallContractArguments()` to get the arguments when `System.call()` is triggered.
- `MockVM.clearCallContractArguments()` to clear the list of call contract arguments.
- `MockVM.clearEvents()` to clear events.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests
